### PR TITLE
conditional addition of serde_urlencoded error

### DIFF
--- a/fusio/src/impls/remotes/http/error.rs
+++ b/fusio/src/impls/remotes/http/error.rs
@@ -17,6 +17,7 @@ pub enum HttpError {
     Reqwest(#[from] reqwest::Error),
     #[error(transparent)]
     Url(#[from] url::ParseError),
+    #[cfg(feature = "serde_urlencoded")]
     #[error(transparent)]
     UrlEncode(#[from] serde_urlencoded::ser::Error),
     #[error(transparent)]


### PR DESCRIPTION
Currently if you create a new project that depends on `fusio` with the `http` feature enabled, you get a compile error:

```
error[E0433]: failed to resolve: use of undeclared crate or module `serde_urlencoded`
  --> /Users/aduffy/.cargo/registry/src/index.crates.io-6f17d22bba15001f/fusio-0.2.0/src/impls/remotes/http/error.rs:21:23
   |
21 |     UrlEncode(#[from] serde_urlencoded::ser::Error),
   |                       ^^^^^^^^^^^^^^^^ use of undeclared crate or module `serde_urlencoded`

   Compiling h2 v0.4.6
   Compiling pyo3-log v0.11.0
For more information about this error, try `rustc --explain E0433`.
error: could not compile `fusio` (lib) due to 1 previous error
```