### PR TITLE
docs: Update Compare to OpenDAL

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ You can freely transmute between them.
 
 ### compare with `opendal`
 
-`fusio` does not aim to be a full data access layer like `opendal`. `fusio` keeps features lean, and you are able to enable features and their dependencies one by one. The default binary size of `fusio` is 245KB, which is much smaller than `opendal` (8.9MB). If you need a full ecosystem of DAL (tracing, cache, etc.), try opendal.
+`fusio` does not aim to be a full data access layer like `opendal`. `fusio` keeps features lean, and you are able to enable features and their dependencies one by one. The default binary size of `fusio` is 245KB, which is smaller than `opendal` (439KB). If you need a full ecosystem of DAL (tracing, cache, etc.), try opendal.
 
 Also, compared with `opendal::Operator`, fusio exposes core traits and allows them to be implemented in third-party crates.
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ You can freely transmute between them.
 
 ### compare with `opendal`
 
-`fusio` does not aim to be a full data access layer like `opendal`. `fusio` keeps features lean, and you are able to enable features and their dependencies one by one. The default binary size of `fusio` is 245KB, which is smaller than `opendal` (439KB). If you need a full ecosystem of DAL (tracing, cache, etc.), try opendal.
+`fusio` does not aim to be a full data access layer like `opendal`. `fusio` keeps features lean, and you are able to enable features and their dependencies one by one. The default binary size of `fusio` is 245KB, which is smaller than `opendal` (439KB). If you need a full ecosystem of DAL (tracing, logging, metrics, retry, etc.), try opendal.
 
 Also, compared with `opendal::Operator`, fusio exposes core traits and allows them to be implemented in third-party crates.
 


### PR DESCRIPTION
Latest opendal will only have `439KB` with default feature enabled:

![image](https://github.com/user-attachments/assets/edb6fcaa-3131-4b34-a10c-16f0ede79842)

---

"Comparing to `opendal::Operator`" isn't fair since opendal exposes `opendal::raw::Access`. However, I'm unsure how to improve this statement.