### PR TITLE
feat: `Fs` adds `copy` & `link`

### DIFF
--- a/fusio-object-store/src/fs.rs
+++ b/fusio-object-store/src/fs.rs
@@ -1,10 +1,10 @@
-use std::{future::Future, sync::Arc};
+use std::sync::Arc;
 
 use async_stream::stream;
 use fusio::{
     fs::{FileMeta, FileSystemTag, Fs, OpenOptions},
     path::Path,
-    Error, MaybeSend,
+    Error,
 };
 use futures_core::Stream;
 use futures_util::stream::StreamExt;

--- a/fusio-object-store/src/fs.rs
+++ b/fusio-object-store/src/fs.rs
@@ -1,10 +1,10 @@
-use std::sync::Arc;
+use std::{future::Future, sync::Arc};
 
 use async_stream::stream;
 use fusio::{
-    fs::{FileMeta, Fs, OpenOptions},
+    fs::{FileMeta, FileSystemTag, Fs, OpenOptions},
     path::Path,
-    Error,
+    Error, MaybeSend,
 };
 use futures_core::Stream;
 use futures_util::stream::StreamExt;
@@ -26,6 +26,10 @@ impl<O: ObjectStore> From<O> for S3Store<O> {
 
 impl<O: ObjectStore> Fs for S3Store<O> {
     type File = S3File<O>;
+
+    fn file_system(&self) -> FileSystemTag {
+        FileSystemTag::S3
+    }
 
     async fn open_options(&self, path: &Path, options: OpenOptions) -> Result<Self::File, Error> {
         if !options.truncate {
@@ -63,5 +67,23 @@ impl<O: ObjectStore> Fs for S3Store<O> {
         self.inner.delete(&path).await.map_err(BoxedError::from)?;
 
         Ok(())
+    }
+
+    fn copy<F: Fs>(
+        &self,
+        from: &Path,
+        to_fs: &F,
+        to: &Path,
+    ) -> impl Future<Output = Result<(), Error>> + MaybeSend {
+        todo!()
+    }
+
+    fn link<F: Fs>(
+        &self,
+        from: &Path,
+        to_fs: &F,
+        to: &Path,
+    ) -> impl Future<Output = Result<(), Error>> + MaybeSend {
+        todo!()
     }
 }

--- a/fusio-object-store/src/fs.rs
+++ b/fusio-object-store/src/fs.rs
@@ -69,21 +69,21 @@ impl<O: ObjectStore> Fs for S3Store<O> {
         Ok(())
     }
 
-    fn copy<F: Fs>(
-        &self,
-        from: &Path,
-        to_fs: &F,
-        to: &Path,
-    ) -> impl Future<Output = Result<(), Error>> + MaybeSend {
-        todo!()
+    async fn copy(&self, from: &Path, to: &Path) -> Result<(), Error> {
+        let from = from.clone().into();
+        let to = to.clone().into();
+
+        self.inner
+            .copy(&from, &to)
+            .await
+            .map_err(BoxedError::from)?;
+
+        Ok(())
     }
 
-    fn link<F: Fs>(
-        &self,
-        from: &Path,
-        to_fs: &F,
-        to: &Path,
-    ) -> impl Future<Output = Result<(), Error>> + MaybeSend {
-        todo!()
+    async fn link<F: Fs>(&self, _: &Path, _: &F, _: &Path) -> Result<(), Error> {
+        Err(Error::Unsupported {
+            message: "s3 does not support link file".to_string(),
+        })
     }
 }

--- a/fusio-object-store/src/fs.rs
+++ b/fusio-object-store/src/fs.rs
@@ -81,7 +81,7 @@ impl<O: ObjectStore> Fs for S3Store<O> {
         Ok(())
     }
 
-    async fn link<F: Fs>(&self, _: &Path, _: &F, _: &Path) -> Result<(), Error> {
+    async fn link(&self, _: &Path, _: &Path) -> Result<(), Error> {
         Err(Error::Unsupported {
             message: "s3 does not support link file".to_string(),
         })

--- a/fusio-opendal/src/fs.rs
+++ b/fusio-opendal/src/fs.rs
@@ -64,16 +64,14 @@ impl Fs for OpendalFs {
             .map_err(parse_opendal_error)
     }
 
-    fn copy(&self, from: &Path, to: &Path) -> impl Future<Output = Result<(), Error>> + MaybeSend {
-        self.op.copy(from.as_ref(), to.as_ref())
+    async fn copy(&self, from: &Path, to: &Path) -> Result<(), Error> {
+        self.op
+            .copy(from.as_ref(), to.as_ref())
+            .await
+            .map_err(parse_opendal_error)
     }
 
-    fn link<F: Fs>(
-        &self,
-        from: &Path,
-        to_fs: &F,
-        to: &Path,
-    ) -> impl Future<Output = Result<(), Error>> + MaybeSend {
+    async fn link<F: Fs>(&self, from: &Path, to_fs: &F, to: &Path) -> Result<(), Error> {
         todo!()
     }
 }

--- a/fusio-opendal/src/fs.rs
+++ b/fusio-opendal/src/fs.rs
@@ -1,7 +1,9 @@
+use std::future::Future;
+
 use fusio::{
-    fs::{FileMeta, Fs, OpenOptions},
+    fs::{FileMeta, FileSystemTag, Fs, OpenOptions},
     path::Path,
-    Error,
+    Error, MaybeSend,
 };
 use futures_core::Stream;
 use futures_util::TryStreamExt;
@@ -24,6 +26,10 @@ impl From<Operator> for OpendalFs {
 
 impl Fs for OpendalFs {
     type File = OpendalFile;
+
+    fn file_system(&self) -> FileSystemTag {
+        todo!()
+    }
 
     async fn open_options(&self, path: &Path, options: OpenOptions) -> Result<Self::File, Error> {
         OpendalFile::open(self.op.clone(), path.to_string(), options).await
@@ -56,5 +62,23 @@ impl Fs for OpendalFs {
             .delete(path.as_ref())
             .await
             .map_err(parse_opendal_error)
+    }
+
+    fn copy<F: Fs>(
+        &self,
+        from: &Path,
+        to_fs: &F,
+        to: &Path,
+    ) -> impl Future<Output = Result<(), Error>> + MaybeSend {
+        todo!()
+    }
+
+    fn link<F: Fs>(
+        &self,
+        from: &Path,
+        to_fs: &F,
+        to: &Path,
+    ) -> impl Future<Output = Result<(), Error>> + MaybeSend {
+        todo!()
     }
 }

--- a/fusio-opendal/src/fs.rs
+++ b/fusio-opendal/src/fs.rs
@@ -1,9 +1,7 @@
-use std::future::Future;
-
 use fusio::{
     fs::{FileMeta, FileSystemTag, Fs, OpenOptions},
     path::Path,
-    Error, MaybeSend,
+    Error,
 };
 use futures_core::Stream;
 use futures_util::TryStreamExt;
@@ -71,7 +69,7 @@ impl Fs for OpendalFs {
             .map_err(parse_opendal_error)
     }
 
-    async fn link(&self, from: &Path, to: &Path) -> Result<(), Error> {
+    async fn link(&self, _from: &Path, _to: &Path) -> Result<(), Error> {
         Err(Error::Unsupported {
             message: "opendal does not support link file".to_string(),
         })

--- a/fusio-opendal/src/fs.rs
+++ b/fusio-opendal/src/fs.rs
@@ -64,13 +64,8 @@ impl Fs for OpendalFs {
             .map_err(parse_opendal_error)
     }
 
-    fn copy<F: Fs>(
-        &self,
-        from: &Path,
-        to_fs: &F,
-        to: &Path,
-    ) -> impl Future<Output = Result<(), Error>> + MaybeSend {
-        todo!()
+    fn copy(&self, from: &Path, to: &Path) -> impl Future<Output = Result<(), Error>> + MaybeSend {
+        self.op.copy(from.as_ref(), to.as_ref())
     }
 
     fn link<F: Fs>(

--- a/fusio-opendal/src/fs.rs
+++ b/fusio-opendal/src/fs.rs
@@ -72,6 +72,8 @@ impl Fs for OpendalFs {
     }
 
     async fn link(&self, from: &Path, to: &Path) -> Result<(), Error> {
-        todo!()
+        Err(Error::Unsupported {
+            message: "opendal does not support link file".to_string(),
+        })
     }
 }

--- a/fusio-opendal/src/fs.rs
+++ b/fusio-opendal/src/fs.rs
@@ -71,7 +71,7 @@ impl Fs for OpendalFs {
             .map_err(parse_opendal_error)
     }
 
-    async fn link<F: Fs>(&self, from: &Path, to_fs: &F, to: &Path) -> Result<(), Error> {
+    async fn link(&self, from: &Path, to: &Path) -> Result<(), Error> {
         todo!()
     }
 }

--- a/fusio/Cargo.toml
+++ b/fusio/Cargo.toml
@@ -80,7 +80,7 @@ hyper = { version = "1", optional = true, default-features = false, features = [
     "http2",
 ] }
 itertools = { version = "0.13" }
-monoio = { version = "0.2", optional = true }
+monoio = { version = "0.2", optional = true, features = ["sync"] }
 object_store = { version = "0.11", optional = true, features = ["aws"] }
 percent-encoding = { version = "2", default-features = false }
 quick-xml = { version = "0.36", features = [

--- a/fusio/src/dynamic/fs.rs
+++ b/fusio/src/dynamic/fs.rs
@@ -94,7 +94,6 @@ pub trait DynFs: MaybeSend + MaybeSync {
     fn link<'s, 'path: 's>(
         &'s self,
         from: &'path Path,
-        to_fs: &'s Self,
         to: &'path Path,
     ) -> Pin<Box<dyn MaybeSendFuture<Output = Result<(), Error>> + 's>>;
 }
@@ -155,14 +154,9 @@ impl<F: Fs> DynFs for F {
     fn link<'s, 'path: 's>(
         &'s self,
         from: &'path Path,
-        to_fs: &'s Self,
         to: &'path Path,
     ) -> Pin<Box<dyn MaybeSendFuture<Output = Result<(), Error>> + 's>> {
-        Box::pin(async move {
-            self.link(from, to_fs, to).await?;
-
-            Ok(())
-        })
+        Box::pin(F::link(self, from, to))
     }
 }
 

--- a/fusio/src/dynamic/fs.rs
+++ b/fusio/src/dynamic/fs.rs
@@ -1,11 +1,11 @@
-use std::pin::Pin;
+use std::{cmp, pin::Pin, sync::Arc};
 
 use futures_core::Stream;
 
 use super::MaybeSendFuture;
 use crate::{
     buf::IoBufMut,
-    fs::{FileMeta, Fs, OpenOptions},
+    fs::{FileMeta, FileSystemTag, Fs, OpenOptions},
     path::Path,
     DynRead, DynWrite, Error, IoBuf, MaybeSend, MaybeSync, Read, Write,
 };
@@ -48,6 +48,8 @@ impl<'write> Write for Box<dyn DynFile + 'write> {
 }
 
 pub trait DynFs: MaybeSend + MaybeSync {
+    fn file_system(&self) -> FileSystemTag;
+
     fn open<'s, 'path: 's>(
         &'s self,
         path: &'path Path,
@@ -99,6 +101,10 @@ pub trait DynFs: MaybeSend + MaybeSync {
 }
 
 impl<F: Fs> DynFs for F {
+    fn file_system(&self) -> FileSystemTag {
+        Fs::file_system(self)
+    }
+
     fn open_options<'s, 'path: 's>(
         &'s self,
         path: &'path Path,
@@ -158,6 +164,43 @@ impl<F: Fs> DynFs for F {
     ) -> Pin<Box<dyn MaybeSendFuture<Output = Result<(), Error>> + 's>> {
         Box::pin(F::link(self, from, to))
     }
+}
+
+pub async fn copy(
+    from_fs: &Arc<dyn DynFs>,
+    from: &Path,
+    to_fs: &Arc<dyn DynFs>,
+    to: &Path,
+) -> Result<(), Error> {
+    if from_fs.file_system() == to_fs.file_system() {
+        from_fs.copy(from, to).await?;
+        return Ok(());
+    }
+    let mut from_file = from_fs
+        .open_options(from, OpenOptions::default().read(true))
+        .await?;
+    let from_file_size = DynRead::size(&from_file).await? as usize;
+
+    let mut to_file = to_fs
+        .open_options(to, OpenOptions::default().create(true).write(true))
+        .await?;
+    let buf_size = cmp::min(from_file_size, 4 * 1024);
+    let mut buf = Some(vec![0u8; buf_size]);
+    let mut read_pos = 0u64;
+
+    while (read_pos as usize) < from_file_size - 1 {
+        let tmp = buf.take().unwrap();
+        let (result, tmp) = Read::read_exact_at(&mut from_file, tmp, read_pos).await;
+        result?;
+        read_pos += tmp.bytes_init() as u64;
+
+        let (result, tmp) = Write::write_all(&mut to_file, tmp).await;
+        result?;
+        buf = Some(tmp);
+    }
+    DynWrite::close(&mut to_file).await?;
+
+    Ok(())
 }
 
 #[cfg(test)]

--- a/fusio/src/error.rs
+++ b/fusio/src/error.rs
@@ -22,9 +22,6 @@ pub enum Error {
     Wasm {
         message: String,
     },
-    #[cfg(feature = "monoio")]
-    #[error("monoio JoinHandle was canceled")]
-    MonoIOJoinCancel,
     #[error(transparent)]
     Other(#[from] BoxedError),
 }
@@ -36,9 +33,4 @@ pub(crate) fn wasm_err(js_val: js_sys::wasm_bindgen::JsValue) -> Error {
     Error::Wasm {
         message: format!("{js_val:?}"),
     }
-}
-
-#[cfg(feature = "monoio")]
-pub(crate) fn monoio_join_err(_: monoio::blocking::JoinError) -> Error {
-    Error::MonoIOJoinCancel
 }

--- a/fusio/src/error.rs
+++ b/fusio/src/error.rs
@@ -22,6 +22,9 @@ pub enum Error {
     Wasm {
         message: String,
     },
+    #[cfg(feature = "monoio")]
+    #[error("monoio JoinHandle was canceled")]
+    MonoIOJoinCancel,
     #[error(transparent)]
     Other(#[from] BoxedError),
 }
@@ -33,4 +36,9 @@ pub(crate) fn wasm_err(js_val: js_sys::wasm_bindgen::JsValue) -> Error {
     Error::Wasm {
         message: format!("{js_val:?}"),
     }
+}
+
+#[cfg(feature = "monoio")]
+pub(crate) fn monoio_join_err(_: monoio::blocking::JoinError) -> Error {
+    Error::MonoIOJoinCancel
 }

--- a/fusio/src/fs/mod.rs
+++ b/fusio/src/fs/mod.rs
@@ -16,10 +16,20 @@ pub struct FileMeta {
     pub size: u64,
 }
 
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum FileSystemTag {
+    Local,
+    OPFS,
+    // TODO: Remote needs to check whether endpoint and other remote fs are consistent
+    S3,
+}
+
 pub trait Fs: MaybeSend + MaybeSync {
     //! This trait is used to abstract file system operations across different file systems.
 
     type File: Read + Write + MaybeSend + 'static;
+
+    fn file_system(&self) -> FileSystemTag;
 
     fn open(&self, path: &Path) -> impl Future<Output = Result<Self::File, Error>> {
         self.open_options(path, OpenOptions::default())
@@ -39,4 +49,18 @@ pub trait Fs: MaybeSend + MaybeSync {
     ) -> impl Future<Output = Result<impl Stream<Item = Result<FileMeta, Error>>, Error>> + MaybeSend;
 
     fn remove(&self, path: &Path) -> impl Future<Output = Result<(), Error>> + MaybeSend;
+
+    fn copy<F: Fs>(
+        &self,
+        from: &Path,
+        to_fs: &F,
+        to: &Path,
+    ) -> impl Future<Output = Result<(), Error>> + MaybeSend;
+
+    fn link<F: Fs>(
+        &self,
+        from: &Path,
+        to_fs: &F,
+        to: &Path,
+    ) -> impl Future<Output = Result<(), Error>> + MaybeSend;
 }

--- a/fusio/src/fs/mod.rs
+++ b/fusio/src/fs/mod.rs
@@ -52,12 +52,7 @@ pub trait Fs: MaybeSend + MaybeSync {
 
     fn copy(&self, from: &Path, to: &Path) -> impl Future<Output = Result<(), Error>> + MaybeSend;
 
-    fn link<F: Fs>(
-        &self,
-        from: &Path,
-        to_fs: &F,
-        to: &Path,
-    ) -> impl Future<Output = Result<(), Error>> + MaybeSend;
+    fn link(&self, from: &Path, to: &Path) -> impl Future<Output = Result<(), Error>> + MaybeSend;
 }
 
 pub async fn copy<F, T>(from_fs: &F, from: &Path, to_fs: &T, to: &Path) -> Result<(), Error>

--- a/fusio/src/fs/mod.rs
+++ b/fusio/src/fs/mod.rs
@@ -8,7 +8,7 @@ use std::{cmp, future::Future};
 use futures_core::Stream;
 pub use options::*;
 
-use crate::{path::Path, Error, IoBufMut, MaybeSend, MaybeSync, Read, Write};
+use crate::{path::Path, Error, MaybeSend, MaybeSync, Read, Write};
 
 #[derive(Debug)]
 pub struct FileMeta {

--- a/fusio/src/fs/mod.rs
+++ b/fusio/src/fs/mod.rs
@@ -3,12 +3,12 @@
 
 mod options;
 
-use std::future::Future;
+use std::{cmp, future::Future};
 
 use futures_core::Stream;
 pub use options::*;
 
-use crate::{path::Path, Error, MaybeSend, MaybeSync, Read, Write};
+use crate::{path::Path, Error, IoBufMut, MaybeSend, MaybeSync, Read, Write};
 
 #[derive(Debug)]
 pub struct FileMeta {
@@ -50,12 +50,7 @@ pub trait Fs: MaybeSend + MaybeSync {
 
     fn remove(&self, path: &Path) -> impl Future<Output = Result<(), Error>> + MaybeSend;
 
-    fn copy<F: Fs>(
-        &self,
-        from: &Path,
-        to_fs: &F,
-        to: &Path,
-    ) -> impl Future<Output = Result<(), Error>> + MaybeSend;
+    fn copy(&self, from: &Path, to: &Path) -> impl Future<Output = Result<(), Error>> + MaybeSend;
 
     fn link<F: Fs>(
         &self,
@@ -63,4 +58,38 @@ pub trait Fs: MaybeSend + MaybeSync {
         to_fs: &F,
         to: &Path,
     ) -> impl Future<Output = Result<(), Error>> + MaybeSend;
+}
+
+pub async fn copy<F, T>(from_fs: &F, from: &Path, to_fs: &T, to: &Path) -> Result<(), Error>
+where
+    F: Fs,
+    T: Fs,
+{
+    if from_fs.file_system() == to_fs.file_system() {
+        from_fs.copy(from, to).await?;
+        return Ok(());
+    }
+    let mut from_file = from_fs
+        .open_options(from, OpenOptions::default().read(true))
+        .await?;
+    let from_file_size = from_file.size().await? as usize;
+
+    let mut to_file = to_fs
+        .open_options(to, OpenOptions::default().create(true).write(true))
+        .await?;
+    let buf_size = cmp::min(from_file_size, 4 * 1024);
+    let mut buf = vec![0u8; buf_size];
+    let mut read_pos = 0u64;
+
+    while (read_pos as usize) < from_file_size - 1 {
+        let (result, _) = from_file.read_exact_at(buf.as_slice_mut(), read_pos).await;
+        result?;
+        read_pos += buf.len() as u64;
+
+        let (result, _) = to_file.write_all(buf.as_slice()).await;
+        result?;
+        buf.resize(buf_size, 0);
+    }
+
+    Ok(())
 }

--- a/fusio/src/fs/mod.rs
+++ b/fusio/src/fs/mod.rs
@@ -57,8 +57,6 @@ pub trait Fs: MaybeSend + MaybeSync {
 
 #[cfg(test)]
 mod tests {
-    use crate::DynFs;
-
     #[ignore]
     #[cfg(all(
         feature = "tokio-http",
@@ -80,7 +78,7 @@ mod tests {
                 aws::{credential::AwsCredential, fs::AmazonS3, options::S3Options, s3::S3File},
                 http::tokio::TokioClient,
             },
-            Read, Write,
+            DynFs, Read, Write,
         };
 
         let tmp_dir = TempDir::new()?;

--- a/fusio/src/impls/disk/monoio/fs.rs
+++ b/fusio/src/impls/disk/monoio/fs.rs
@@ -61,15 +61,11 @@ impl Fs for MonoIoFs {
         Ok(fs::remove_file(path)?)
     }
 
-    async fn copy<F: Fs>(&self, from: &Path, to_fs: &F, to: &Path) -> Result<(), Error> {
-        if self.file_system() == to_fs.file_system() {
-            let from = path_to_local(from)?;
-            let to = path_to_local(to)?;
+    async fn copy(&self, from: &Path, to: &Path) -> Result<(), Error> {
+        let from = path_to_local(from)?;
+        let to = path_to_local(to)?;
 
-            fs::copy(&from, &to)?;
-        } else {
-            todo!()
-        }
+        fs::copy(&from, &to)?;
 
         Ok(())
     }

--- a/fusio/src/impls/disk/monoio/fs.rs
+++ b/fusio/src/impls/disk/monoio/fs.rs
@@ -65,7 +65,7 @@ impl Fs for MonoIoFs {
         let from = path_to_local(from)?;
         let to = path_to_local(to)?;
 
-        let _ = monoio::spawn(async move { fs::copy(&from, &to) }).await?;
+        monoio::spawn(async move { fs::copy(&from, &to) }).await?;
 
         Ok(())
     }
@@ -74,7 +74,7 @@ impl Fs for MonoIoFs {
         let from = path_to_local(from)?;
         let to = path_to_local(to)?;
 
-        let _ = monoio::spawn(async move { fs::hard_link(&from, &to) }).await?;
+        monoio::spawn(async move { fs::hard_link(&from, &to) }).await?;
 
         Ok(())
     }

--- a/fusio/src/impls/disk/monoio/fs.rs
+++ b/fusio/src/impls/disk/monoio/fs.rs
@@ -70,12 +70,7 @@ impl Fs for MonoIoFs {
         Ok(())
     }
 
-    async fn link<F: Fs>(&self, from: &Path, to_fs: &F, to: &Path) -> Result<(), Error> {
-        if self.file_system() != to_fs.file_system() {
-            return Err(Error::Unsupported {
-                message: "file system is inconsistent".to_string(),
-            });
-        }
+    async fn link(&self, from: &Path, to: &Path) -> Result<(), Error> {
         let from = path_to_local(from)?;
         let to = path_to_local(to)?;
 

--- a/fusio/src/impls/disk/monoio/fs.rs
+++ b/fusio/src/impls/disk/monoio/fs.rs
@@ -2,11 +2,9 @@ use std::{fs, fs::create_dir_all};
 
 use async_stream::stream;
 use futures_core::Stream;
-use monoio::blocking::spawn_blocking;
 
 use super::MonoioFile;
 use crate::{
-    error::monoio_join_err,
     fs::{FileMeta, FileSystemTag, Fs, OpenOptions},
     path::{path_to_local, Path},
     Error,
@@ -67,9 +65,7 @@ impl Fs for MonoIoFs {
         let from = path_to_local(from)?;
         let to = path_to_local(to)?;
 
-        spawn_blocking(move || fs::copy(&from, &to))
-            .await
-            .map_err(monoio_join_err)??;
+        let _ = monoio::spawn(async move { fs::copy(&from, &to) }).await?;
 
         Ok(())
     }
@@ -78,9 +74,7 @@ impl Fs for MonoIoFs {
         let from = path_to_local(from)?;
         let to = path_to_local(to)?;
 
-        spawn_blocking(move || fs::hard_link(&from, &to))
-            .await
-            .map_err(monoio_join_err)??;
+        let _ = monoio::spawn(async move { fs::hard_link(&from, &to) }).await?;
 
         Ok(())
     }

--- a/fusio/src/impls/disk/opfs/fs.rs
+++ b/fusio/src/impls/disk/opfs/fs.rs
@@ -104,13 +104,13 @@ impl Fs for OPFS {
         Ok(())
     }
 
-    async fn copy(&self, from: &Path, to: &Path) -> Result<(), Error> {
+    async fn copy(&self, _: &Path, _: &Path) -> Result<(), Error> {
         Err(Error::Unsupported {
             message: "opfs does not support copy file".to_string(),
         })
     }
 
-    async fn link<F: Fs>(&self, from: &Path, to_fs: &F, to: &Path) -> Result<(), Error> {
+    async fn link(&self, _: &Path, _: &Path) -> Result<(), Error> {
         Err(Error::Unsupported {
             message: "opfs does not support link file".to_string(),
         })

--- a/fusio/src/impls/disk/opfs/fs.rs
+++ b/fusio/src/impls/disk/opfs/fs.rs
@@ -104,7 +104,7 @@ impl Fs for OPFS {
         Ok(())
     }
 
-    async fn copy<F: Fs>(&self, from: &Path, to: &Path) -> Result<(), Error> {
+    async fn copy(&self, from: &Path, to: &Path) -> Result<(), Error> {
         Err(Error::Unsupported {
             message: "opfs does not support copy file".to_string(),
         })

--- a/fusio/src/impls/disk/opfs/fs.rs
+++ b/fusio/src/impls/disk/opfs/fs.rs
@@ -104,23 +104,13 @@ impl Fs for OPFS {
         Ok(())
     }
 
-    fn copy<F: Fs>(
-        &self,
-        from: &Path,
-        to_fs: &F,
-        to: &Path,
-    ) -> impl Future<Output = Result<(), Error>> + MaybeSend {
+    async fn copy<F: Fs>(&self, from: &Path, to: &Path) -> Result<(), Error> {
         Err(Error::Unsupported {
             message: "opfs does not support copy file".to_string(),
         })
     }
 
-    fn link<F: Fs>(
-        &self,
-        from: &Path,
-        to_fs: &F,
-        to: &Path,
-    ) -> impl Future<Output = Result<(), Error>> + MaybeSend {
+    async fn link<F: Fs>(&self, from: &Path, to_fs: &F, to: &Path) -> Result<(), Error> {
         Err(Error::Unsupported {
             message: "opfs does not support link file".to_string(),
         })

--- a/fusio/src/impls/disk/tokio/fs.rs
+++ b/fusio/src/impls/disk/tokio/fs.rs
@@ -81,12 +81,7 @@ impl Fs for TokioFs {
         Ok(())
     }
 
-    async fn link<F: Fs>(&self, from: &Path, to_fs: &F, to: &Path) -> Result<(), Error> {
-        if self.file_system() != to_fs.file_system() {
-            return Err(Error::Unsupported {
-                message: "file system is inconsistent".to_string(),
-            });
-        }
+    async fn link(&self, from: &Path, to: &Path) -> Result<(), Error> {
         let from = path_to_local(from)?;
         let to = path_to_local(to)?;
 

--- a/fusio/src/impls/disk/tokio/fs.rs
+++ b/fusio/src/impls/disk/tokio/fs.rs
@@ -72,15 +72,11 @@ impl Fs for TokioFs {
         Ok(())
     }
 
-    async fn copy<F: Fs>(&self, from: &Path, to_fs: &F, to: &Path) -> Result<(), Error> {
-        if self.file_system() == to_fs.file_system() {
-            let from = path_to_local(from)?;
-            let to = path_to_local(to)?;
+    async fn copy(&self, from: &Path, to: &Path) -> Result<(), Error> {
+        let from = path_to_local(from)?;
+        let to = path_to_local(to)?;
 
-            tokio::fs::copy(&from, &to).await?;
-        } else {
-            todo!()
-        }
+        tokio::fs::copy(&from, &to).await?;
 
         Ok(())
     }

--- a/fusio/src/impls/disk/tokio/fs.rs
+++ b/fusio/src/impls/disk/tokio/fs.rs
@@ -27,7 +27,7 @@ impl Fs for TokioFs {
 
         let file = tokio::fs::OpenOptions::new()
             .read(options.read)
-            .append(options.write)
+            .write(options.write)
             .create(options.create)
             .open(&local_path)
             .await?;

--- a/fusio/src/impls/disk/tokio_uring/fs.rs
+++ b/fusio/src/impls/disk/tokio_uring/fs.rs
@@ -74,12 +74,7 @@ impl Fs for TokioUringFs {
         Ok(())
     }
 
-    async fn link<F: Fs>(&self, from: &Path, to_fs: &F, to: &Path) -> Result<(), Error> {
-        if self.file_system() != to_fs.file_system() {
-            return Err(Error::Unsupported {
-                message: "file system is inconsistent".to_string(),
-            });
-        }
+    async fn link(&self, from: &Path, to: &Path) -> Result<(), Error> {
         let from = path_to_local(from)?;
         let to = path_to_local(to)?;
 

--- a/fusio/src/impls/disk/tokio_uring/fs.rs
+++ b/fusio/src/impls/disk/tokio_uring/fs.rs
@@ -65,15 +65,11 @@ impl Fs for TokioUringFs {
         Ok(remove_file(path).await?)
     }
 
-    async fn copy<F: Fs>(&self, from: &Path, to_fs: &F, to: &Path) -> Result<(), Error> {
-        if self.file_system() == to_fs.file_system() {
-            let from = path_to_local(from)?;
-            let to = path_to_local(to)?;
+    async fn copy(&self, from: &Path, to: &Path) -> Result<(), Error> {
+        let from = path_to_local(from)?;
+        let to = path_to_local(to)?;
 
-            fs::copy(&from, &to)?;
-        } else {
-            todo!()
-        }
+        fs::copy(&from, &to)?;
 
         Ok(())
     }

--- a/fusio/src/impls/disk/tokio_uring/fs.rs
+++ b/fusio/src/impls/disk/tokio_uring/fs.rs
@@ -1,18 +1,24 @@
+use std::{fs, future::Future};
+
 use async_stream::stream;
 use futures_core::Stream;
 use tokio_uring::fs::{create_dir_all, remove_file};
 
 use crate::{
     disk::tokio_uring::TokioUringFile,
-    fs::{FileMeta, Fs, OpenOptions},
+    fs::{FileMeta, FileSystemTag, Fs, OpenOptions},
     path::{path_to_local, Path},
-    Error,
+    Error, MaybeSend,
 };
 
 pub struct TokioUringFs;
 
 impl Fs for TokioUringFs {
     type File = TokioUringFile;
+
+    fn file_system(&self) -> FileSystemTag {
+        FileSystemTag::Local
+    }
 
     async fn open_options(&self, path: &Path, options: OpenOptions) -> Result<Self::File, Error> {
         let local_path = path_to_local(path)?;
@@ -57,5 +63,32 @@ impl Fs for TokioUringFs {
         let path = path_to_local(path)?;
 
         Ok(remove_file(path).await?)
+    }
+
+    async fn copy<F: Fs>(&self, from: &Path, to_fs: &F, to: &Path) -> Result<(), Error> {
+        if self.file_system() == to_fs.file_system() {
+            let from = path_to_local(from)?;
+            let to = path_to_local(to)?;
+
+            fs::copy(&from, &to)?;
+        } else {
+            todo!()
+        }
+
+        Ok(())
+    }
+
+    async fn link<F: Fs>(&self, from: &Path, to_fs: &F, to: &Path) -> Result<(), Error> {
+        if self.file_system() != to_fs.file_system() {
+            return Err(Error::Unsupported {
+                message: "file system is inconsistent".to_string(),
+            });
+        }
+        let from = path_to_local(from)?;
+        let to = path_to_local(to)?;
+
+        fs::hard_link(&from, &to)?;
+
+        Ok(())
     }
 }

--- a/fusio/src/impls/remotes/aws/fs.rs
+++ b/fusio/src/impls/remotes/aws/fs.rs
@@ -11,7 +11,7 @@ use url::Url;
 
 use super::{credential::AwsCredential, options::S3Options, S3Error, S3File};
 use crate::{
-    fs::{FileMeta, Fs, OpenOptions},
+    fs::{FileMeta, FileSystemTag, Fs, OpenOptions},
     path::Path,
     remotes::{
         aws::sign::Sign,
@@ -125,6 +125,10 @@ pub(super) struct AmazonS3Inner {
 impl Fs for AmazonS3 {
     type File = S3File;
 
+    fn file_system(&self) -> FileSystemTag {
+        FileSystemTag::S3
+    }
+
     async fn open_options(&self, path: &Path, _: OpenOptions) -> Result<Self::File, crate::Error> {
         Ok(S3File::new(self.clone(), path.clone()))
     }
@@ -233,6 +237,14 @@ impl Fs for AmazonS3 {
         }
 
         Ok(())
+    }
+
+    async fn copy<F: Fs>(&self, from: &Path, to_fs: &F, to: &Path) -> Result<(), Error> {
+        todo!()
+    }
+
+    async fn link<F: Fs>(&self, from: &Path, to_fs: &F, to: &Path) -> Result<(), Error> {
+        todo!()
     }
 }
 

--- a/fusio/src/impls/remotes/aws/fs.rs
+++ b/fusio/src/impls/remotes/aws/fs.rs
@@ -127,8 +127,10 @@ pub(super) struct AmazonS3Inner {
 }
 
 impl AmazonS3 {
-    pub fn new(client: Box<dyn DynHttpClient>, options: S3Options) -> Self {
+    #[allow(dead_code)]
+    pub(crate) fn new(client: Box<dyn DynHttpClient>, options: S3Options) -> Self {
         AmazonS3 {
+            #[allow(clippy::arc_with_non_send_sync)]
             inner: Arc::new(AmazonS3Inner { options, client }),
         }
     }
@@ -300,6 +302,7 @@ pub struct ListResponse {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "tokio-http")]
     use crate::{fs::Fs, path::Path};
 
     #[cfg(feature = "tokio-http")]

--- a/fusio/src/impls/remotes/aws/fs.rs
+++ b/fusio/src/impls/remotes/aws/fs.rs
@@ -20,7 +20,7 @@ use crate::{
         },
         http::{DynHttpClient, HttpClient, HttpError},
     },
-    Error, Read,
+    Error,
 };
 
 pub struct AmazonS3Builder {
@@ -350,7 +350,7 @@ mod tests {
                     options::S3Options,
                     s3::S3File,
                 },
-                http::{tokio::TokioClient, DynHttpClient, HttpClient},
+                http::{tokio::TokioClient, DynHttpClient},
             },
             Read, Write,
         };

--- a/fusio/src/impls/remotes/aws/fs.rs
+++ b/fusio/src/impls/remotes/aws/fs.rs
@@ -264,7 +264,7 @@ impl Fs for AmazonS3 {
         Ok(())
     }
 
-    async fn link<F: Fs>(&self, _: &Path, _: &F, _: &Path) -> Result<(), Error> {
+    async fn link(&self, _: &Path, _: &Path) -> Result<(), Error> {
         Err(Error::Unsupported {
             message: "s3 does not support link file".to_string(),
         })

--- a/fusio/src/impls/remotes/aws/mod.rs
+++ b/fusio/src/impls/remotes/aws/mod.rs
@@ -4,7 +4,7 @@ mod error;
 pub mod fs;
 pub(crate) mod multipart_upload;
 pub(crate) mod options;
-mod s3;
+pub(crate) mod s3;
 pub(crate) mod sign;
 pub(crate) mod writer;
 

--- a/fusio/src/impls/remotes/aws/multipart_upload.rs
+++ b/fusio/src/impls/remotes/aws/multipart_upload.rs
@@ -80,24 +80,14 @@ impl MultipartUpload {
         Self::check_response(response).await
     }
 
-    pub(crate) async fn upload_once<B>(
-        &self,
-        upload_type: UploadType<B>,
-    ) -> Result<(), Error>
+    pub(crate) async fn upload_once<B>(&self, upload_type: UploadType<B>) -> Result<(), Error>
     where
         B: Body<Data = Bytes> + Clone + Unpin + Send + Sync + 'static,
         B::Error: std::error::Error + Send + Sync + 'static,
     {
         let (size, body, copy_from) = match upload_type {
-            UploadType::Write {
-                size,
-                body
-            } => (Some(size), body, None),
-            UploadType::Copy {
-                bucket,
-                from,
-                body,
-            } => {
+            UploadType::Write { size, body } => (Some(size), body, None),
+            UploadType::Copy { bucket, from, body } => {
                 let from_url = format!(
                     "/{bucket}/{}",
                     utf8_percent_encode(from.as_ref(), &STRICT_PATH_ENCODE_SET)
@@ -110,9 +100,7 @@ impl MultipartUpload {
             self.fs.as_ref().options.endpoint,
             utf8_percent_encode(self.path.as_ref(), &STRICT_PATH_ENCODE_SET)
         );
-        let mut builder = Request::builder()
-            .uri(url)
-            .method(Method::PUT);
+        let mut builder = Request::builder().uri(url).method(Method::PUT);
         if let Some(from_url) = copy_from {
             builder = builder.header("x-amz-copy-source", from_url);
         }

--- a/fusio/src/impls/remotes/aws/options.rs
+++ b/fusio/src/impls/remotes/aws/options.rs
@@ -2,6 +2,7 @@ use super::credential::AwsCredential;
 
 pub(crate) struct S3Options {
     pub(crate) endpoint: String,
+    pub(crate) bucket: String,
     pub(crate) region: String,
     pub(crate) credential: Option<AwsCredential>,
     pub(crate) sign_payload: bool,

--- a/fusio/src/impls/remotes/aws/s3.rs
+++ b/fusio/src/impls/remotes/aws/s3.rs
@@ -254,7 +254,8 @@ impl Write for S3File {
 
 #[cfg(test)]
 mod tests {
-    #[ignore]
+    use crate::Write;
+
     #[cfg(all(feature = "tokio-http", not(feature = "completion-based")))]
     #[tokio::test]
     async fn write_and_read_s3_file() {
@@ -280,6 +281,7 @@ mod tests {
         let region = "ap-southeast-1";
         let options = S3Options {
             endpoint: "http://localhost:9000/data".into(),
+            bucket: "data".to_string(),
             credential: Some(AwsCredential {
                 key_id,
                 secret_key,
@@ -297,12 +299,16 @@ mod tests {
             }),
         };
 
-        let mut s3 = S3File::new(s3, "read-write.txt".into());
+        {
+            let mut s3 = S3File::new(s3.clone(), "read-write.txt".into());
 
-        let (result, _) = s3
-            .write_all(&b"The answer of life, universe and everthing"[..])
-            .await;
-        result.unwrap();
+            let (result, _) = s3
+                .write_all(&b"The answer of life, universe and everthing"[..])
+                .await;
+            result.unwrap();
+            s3.close().await.unwrap();
+        }
+        let mut s3 = S3File::new(s3, "read-write.txt".into());
 
         let size = s3.size().await.unwrap();
         assert_eq!(size, 42);

--- a/fusio/src/impls/remotes/aws/s3.rs
+++ b/fusio/src/impls/remotes/aws/s3.rs
@@ -254,8 +254,8 @@ impl Write for S3File {
 
 #[cfg(test)]
 mod tests {
-    use crate::Write;
 
+    #[ignore]
     #[cfg(all(feature = "tokio-http", not(feature = "completion-based")))]
     #[tokio::test]
     async fn write_and_read_s3_file() {

--- a/fusio/src/impls/remotes/aws/s3.rs
+++ b/fusio/src/impls/remotes/aws/s3.rs
@@ -269,7 +269,7 @@ mod tests {
                     options::S3Options,
                     s3::S3File,
                 },
-                http::{tokio::TokioClient, DynHttpClient, HttpClient},
+                http::{tokio::TokioClient, DynHttpClient},
             },
             Read, Write,
         };

--- a/fusio/src/impls/remotes/aws/writer.rs
+++ b/fusio/src/impls/remotes/aws/writer.rs
@@ -2,7 +2,7 @@ use std::{mem, pin::Pin, sync::Arc};
 
 use bytes::{BufMut, BytesMut};
 use futures_util::{stream::FuturesOrdered, StreamExt};
-use http_body_util::{Empty, Full};
+use http_body_util::Full;
 
 use crate::{
     dynamic::MaybeSendFuture,

--- a/fusio/src/impls/remotes/aws/writer.rs
+++ b/fusio/src/impls/remotes/aws/writer.rs
@@ -2,11 +2,14 @@ use std::{mem, pin::Pin, sync::Arc};
 
 use bytes::{BufMut, BytesMut};
 use futures_util::{stream::FuturesOrdered, StreamExt};
-use http_body_util::Full;
+use http_body_util::{Empty, Full};
 
 use crate::{
     dynamic::MaybeSendFuture,
-    remotes::{aws::multipart_upload::MultipartUpload, serde::MultipartPart},
+    remotes::{
+        aws::multipart_upload::{MultipartUpload, UploadType},
+        serde::MultipartPart,
+    },
     Error, IoBuf, Write,
 };
 
@@ -90,7 +93,7 @@ impl Write for S3Writer {
                 let bytes = mem::replace(&mut self.buf, BytesMut::new()).freeze();
 
                 self.inner
-                    .upload_once(bytes.len(), Full::new(bytes))
+                    .upload_once(bytes.len(), UploadType::Write(Full::new(bytes)))
                     .await?;
             }
             return Ok(());

--- a/fusio/src/impls/remotes/aws/writer.rs
+++ b/fusio/src/impls/remotes/aws/writer.rs
@@ -93,7 +93,10 @@ impl Write for S3Writer {
                 let bytes = mem::replace(&mut self.buf, BytesMut::new()).freeze();
 
                 self.inner
-                    .upload_once(bytes.len(), UploadType::Write(Full::new(bytes)))
+                    .upload_once(UploadType::Write {
+                        size: bytes.len(),
+                        body: Full::new(bytes),
+                    })
                     .await?;
             }
             return Ok(());
@@ -143,6 +146,7 @@ mod tests {
         let region = "ap-southeast-2";
         let options = S3Options {
             endpoint: "http://localhost:9000/data".into(),
+            bucket: "data".to_string(),
             credential: Some(AwsCredential {
                 key_id: "user".to_string(),
                 secret_key: "password".to_string(),

--- a/fusio/src/lib.rs
+++ b/fusio/src/lib.rs
@@ -377,10 +377,17 @@ mod tests {
                 )
                 .await?;
             file.write_all("Hello! world".as_bytes()).await.0?;
-
+            file.flush().await.unwrap();
             file.close().await.unwrap();
 
-            let (result, buf) = file.read_exact_at(vec![0u8; 12], 12).await;
+            let mut file = fs
+                .open_options(
+                    &Path::from_absolute_path(&work_file_path)?,
+                    OpenOptions::default().read(true),
+                )
+                .await?;
+
+            let (result, buf) = file.read_exact_at(vec![0u8; 12], 0).await;
             result.unwrap();
             assert_eq!(buf.as_slice(), b"Hello! world");
         }
@@ -452,9 +459,17 @@ mod tests {
                 )
                 .await?;
             src_file.write_all("Hello! world".as_bytes()).await.0?;
+            src_file.flush().await?;
             src_file.close().await?;
 
-            let (result, buf) = src_file.read_exact_at(vec![0u8; 12], 12).await;
+            let mut src_file = src_fs
+                .open_options(
+                    &Path::from_absolute_path(&src_file_path)?,
+                    OpenOptions::default().write(true).read(true),
+                )
+                .await?;
+
+            let (result, buf) = src_file.read_exact_at(vec![0u8; 12], 0).await;
             result.unwrap();
             assert_eq!(buf.as_slice(), b"Hello! world");
 
@@ -499,9 +514,16 @@ mod tests {
                 )
                 .await?;
             src_file.write_all("Hello! world".as_bytes()).await.0?;
+            src_file.flush().await?;
             src_file.close().await?;
 
-            let (result, buf) = src_file.read_exact_at(vec![0u8; 12], 12).await;
+            let mut src_file = src_fs
+                .open_options(
+                    &Path::from_absolute_path(&src_file_path)?,
+                    OpenOptions::default().write(true).read(true),
+                )
+                .await?;
+            let (result, buf) = src_file.read_exact_at(vec![0u8; 12], 0).await;
             result.unwrap();
             assert_eq!(buf.as_slice(), b"Hello! world");
 
@@ -512,9 +534,9 @@ mod tests {
                 )
                 .await?;
 
-            let (result, buf) = dst_file.read_exact_at(vec![0u8; 24], 0).await;
+            let (result, buf) = dst_file.read_exact_at(vec![0u8; 12], 0).await;
             result.unwrap();
-            assert_eq!(buf.as_slice(), b"Hello! fusioHello! world");
+            assert_eq!(buf.as_slice(), b"Hello! world");
         }
 
         Ok(())

--- a/fusio/src/lib.rs
+++ b/fusio/src/lib.rs
@@ -395,6 +395,7 @@ mod tests {
         Ok(())
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
     #[allow(unused)]
     async fn test_local_fs_copy_link<F: crate::fs::Fs>(src_fs: F) -> Result<(), Error> {
         use std::collections::HashSet;

--- a/fusio/src/lib.rs
+++ b/fusio/src/lib.rs
@@ -542,18 +542,20 @@ mod tests {
     }
 
     #[cfg(all(feature = "tokio-uring", target_os = "linux"))]
-    #[tokio::test]
-    async fn test_tokio_uring_fs() {
+    #[test]
+    fn test_tokio_uring_fs() {
         use crate::disk::tokio_uring::fs::TokioUringFs;
 
-        test_local_fs_read_write(TokioUringFs).await.unwrap();
-        test_local_fs_copy_link(TokioUringFs, TokioUringFs)
-            .await
-            .unwrap();
+        tokio_uring::start(async {
+            test_local_fs_read_write(TokioUringFs).await.unwrap();
+            test_local_fs_copy_link(TokioUringFs, TokioUringFs)
+                .await
+                .unwrap();
+        })
     }
 
     #[cfg(all(feature = "monoio", not(target_arch = "wasm32")))]
-    #[tokio::test]
+    #[monoio::test]
     async fn test_monoio_fs() {
         use crate::disk::monoio::fs::MonoIoFs;
 

--- a/fusio/src/lib.rs
+++ b/fusio/src/lib.rs
@@ -327,7 +327,7 @@ mod tests {
 
     #[allow(unused)]
     #[cfg(not(target_arch = "wasm32"))]
-    async fn test_local_fs<S>(fs: S) -> Result<(), Error>
+    async fn test_local_fs_read_write<S>(fs: S) -> Result<(), Error>
     where
         S: crate::fs::Fs,
     {
@@ -388,7 +388,140 @@ mod tests {
         Ok(())
     }
 
-    #[cfg(feature = "tokio")]
+    #[allow(unused)]
+    async fn test_local_fs_copy_link<S, D>(src_fs: S, dst_fs: D) -> Result<(), Error>
+    where
+        S: crate::fs::Fs,
+        D: crate::fs::Fs,
+    {
+        use std::collections::HashSet;
+
+        use futures_util::StreamExt;
+        use tempfile::TempDir;
+
+        use crate::{fs::OpenOptions, path::Path, DynFs};
+
+        let tmp_dir = TempDir::new()?;
+
+        let work_dir_path = tmp_dir.path().join("work_dir");
+        let src_file_path = work_dir_path.join("src_test.file");
+        let dst_file_path = work_dir_path.join("dst_test.file");
+
+        src_fs
+            .create_dir_all(&Path::from_absolute_path(&work_dir_path)?)
+            .await?;
+        dst_fs
+            .create_dir_all(&Path::from_absolute_path(&work_dir_path)?)
+            .await?;
+
+        // create files
+        let _ = src_fs
+            .open_options(
+                &Path::from_absolute_path(&src_file_path)?,
+                OpenOptions::default().create(true),
+            )
+            .await?;
+        let _ = dst_fs
+            .open_options(
+                &Path::from_absolute_path(&dst_file_path)?,
+                OpenOptions::default().create(true),
+            )
+            .await?;
+        // copy
+        {
+            let mut src_file = src_fs
+                .open_options(
+                    &Path::from_absolute_path(&src_file_path)?,
+                    OpenOptions::default().write(true),
+                )
+                .await?;
+            src_file.write_all("Hello! fusio".as_bytes()).await.0?;
+            src_file.close().await?;
+
+            src_fs
+                .copy(
+                    &Path::from_absolute_path(&src_file_path)?,
+                    &dst_fs,
+                    &Path::from_absolute_path(&dst_file_path)?,
+                )
+                .await?;
+
+            let mut src_file = src_fs
+                .open_options(
+                    &Path::from_absolute_path(&src_file_path)?,
+                    OpenOptions::default().write(true).read(true),
+                )
+                .await?;
+            src_file.write_all("Hello! world".as_bytes()).await.0?;
+            src_file.close().await?;
+
+            let (result, buf) = src_file.read_exact_at(vec![0u8; 12], 12).await;
+            result.unwrap();
+            assert_eq!(buf.as_slice(), b"Hello! world");
+
+            let mut dst_file = dst_fs
+                .open_options(
+                    &Path::from_absolute_path(&dst_file_path)?,
+                    OpenOptions::default().read(true),
+                )
+                .await?;
+
+            let (result, buf) = dst_file.read_exact_at(vec![0u8; 12], 0).await;
+            result.unwrap();
+            assert_eq!(buf.as_slice(), b"Hello! fusio");
+        }
+
+        dst_fs
+            .remove(&Path::from_absolute_path(&dst_file_path)?)
+            .await?;
+        // link
+        {
+            let mut src_file = src_fs
+                .open_options(
+                    &Path::from_absolute_path(&src_file_path)?,
+                    OpenOptions::default().write(true),
+                )
+                .await?;
+            src_file.write_all("Hello! fusio".as_bytes()).await.0?;
+            src_file.close().await?;
+
+            src_fs
+                .link(
+                    &Path::from_absolute_path(&src_file_path)?,
+                    &dst_fs,
+                    &Path::from_absolute_path(&dst_file_path)?,
+                )
+                .await?;
+
+            let mut src_file = src_fs
+                .open_options(
+                    &Path::from_absolute_path(&src_file_path)?,
+                    OpenOptions::default().write(true).read(true),
+                )
+                .await?;
+            src_file.write_all("Hello! world".as_bytes()).await.0?;
+            src_file.close().await?;
+
+            let (result, buf) = src_file.read_exact_at(vec![0u8; 12], 12).await;
+            result.unwrap();
+            assert_eq!(buf.as_slice(), b"Hello! world");
+
+            let mut dst_file = dst_fs
+                .open_options(
+                    &Path::from_absolute_path(&dst_file_path)?,
+                    OpenOptions::default().read(true),
+                )
+                .await?;
+
+            let (result, buf) = dst_file.read_exact_at(vec![0u8; 24], 0).await;
+            result.unwrap();
+            assert_eq!(buf.as_slice(), b"Hello! fusioHello! world");
+        }
+
+        Ok(())
+    }
+
+    #[cfg(all(feature = "tokio", not(target_arch = "wasm32")))]
     #[tokio::test]
     async fn test_tokio() {
         use tempfile::tempfile;
@@ -405,10 +538,31 @@ mod tests {
     async fn test_tokio_fs() {
         use crate::disk::TokioFs;
 
-        test_local_fs(TokioFs).await.unwrap();
+        test_local_fs_read_write(TokioFs).await.unwrap();
+        test_local_fs_copy_link(TokioFs, TokioFs).await.unwrap();
     }
 
-    #[cfg(feature = "tokio")]
+    #[cfg(all(feature = "tokio-uring", target_os = "linux"))]
+    #[tokio::test]
+    async fn test_tokio_uring_fs() {
+        use crate::disk::tokio_uring::fs::TokioUringFs;
+
+        test_local_fs_read_write(TokioUringFs).await.unwrap();
+        test_local_fs_copy_link(TokioUringFs, TokioUringFs)
+            .await
+            .unwrap();
+    }
+
+    #[cfg(all(feature = "monoio", not(target_arch = "wasm32")))]
+    #[tokio::test]
+    async fn test_monoio_fs() {
+        use crate::disk::monoio::fs::MonoIoFs;
+
+        test_local_fs_read_write(MonoIoFs).await.unwrap();
+        test_local_fs_copy_link(MonoIoFs, MonoIoFs).await.unwrap();
+    }
+
+    #[cfg(all(feature = "tokio", not(target_arch = "wasm32")))]
     #[tokio::test]
     async fn test_read_exact() {
         use tempfile::tempfile;

--- a/fusio/src/lib.rs
+++ b/fusio/src/lib.rs
@@ -441,7 +441,6 @@ mod tests {
             src_fs
                 .copy(
                     &Path::from_absolute_path(&src_file_path)?,
-                    &dst_fs,
                     &Path::from_absolute_path(&dst_file_path)?,
                 )
                 .await?;


### PR DESCRIPTION
ref: https://github.com/tonbo-io/fusio/issues/99

- [x] local filesystem can implement `link` and `copy`
- [x] s3 can implement  `copy`
- [x] Implement file copy between different filesystems e.g. src: `TokioFs` & dst: `AmazonS3`