### PR TITLE
make opfs available in web worker

### DIFF
--- a/fusio/Cargo.toml
+++ b/fusio/Cargo.toml
@@ -124,6 +124,8 @@ web-sys = { version = "0.3", optional = true, features = [
     "Storage",
     "StorageManager",
     "Window",
+    "WorkerGlobalScope",
+    "WorkerNavigator",
 
 ] }
 

--- a/fusio/src/impls/disk/opfs/fs.rs
+++ b/fusio/src/impls/disk/opfs/fs.rs
@@ -19,7 +19,7 @@ use crate::{
     error::wasm_err,
     fs::{FileMeta, FileSystemTag, Fs, OpenOptions},
     path::Path,
-    Error, MaybeSend,
+    Error,
 };
 
 pub struct OPFS;
@@ -122,7 +122,7 @@ impl OPFS {
         path: &Path,
         options: &FileSystemGetDirectoryOptions,
     ) -> Result<FileSystemDirectoryHandle, Error> {
-        let mut parent = storage().await;
+        let mut parent = storage().await?;
         let segments: Vec<&str> = path.as_ref().trim_matches('/').split("/").collect();
 
         if segments.len() == 1 && segments[0].is_empty() {
@@ -148,7 +148,7 @@ impl OPFS {
         path: &Path,
         options: &FileSystemGetDirectoryOptions,
     ) -> Result<FileSystemDirectoryHandle, Error> {
-        let mut parent = storage().await;
+        let mut parent = storage().await?;
         let segments: Vec<&str> = path.as_ref().trim_matches('/').split("/").collect();
         let part_len = segments.len();
 


### PR DESCRIPTION
Fusio can not get `Window` in web worker now, resulting in opfs root directory is not available. This PR make opfs root directory available in web worker

https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Using_web_workers#web_workers_api

https://developer.mozilla.org/en-US/docs/Web/API/WorkerGlobalScope/navigator