### PR TITLE
fix: add missing http headers under wasm

### DIFF
--- a/fusio/Cargo.toml
+++ b/fusio/Cargo.toml
@@ -68,6 +68,7 @@ cfg-if = "1.0.0"
 chrono = { version = "0.4", optional = true, default-features = false, features = [
     "now",
     "std",
+    "wasmbind"
 ] }
 futures-core = { version = "0.3" }
 futures-util = { version = "0.3" }

--- a/fusio/tests/wasm_http.rs
+++ b/fusio/tests/wasm_http.rs
@@ -1,0 +1,53 @@
+#[cfg(all(feature = "wasm-http", target_arch = "wasm32", test))]
+pub(crate) mod tests {
+
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
+    use wasm_bindgen_test::wasm_bindgen_test;
+
+    #[ignore]
+    #[cfg(feature = "aws")]
+    #[wasm_bindgen_test]
+    async fn test_read_write_s3_wasm() {
+        use fusio::{
+            fs::Fs,
+            remotes::aws::{fs::AmazonS3Builder, AwsCredential},
+            Read, Write,
+        };
+
+        if option_env!("AWS_ACCESS_KEY_ID").is_none() {
+            return;
+        }
+        let key_id = option_env!("AWS_ACCESS_KEY_ID").unwrap().to_string();
+        let secret_key = option_env!("AWS_SECRET_ACCESS_KEY").unwrap().to_string();
+
+        let s3 = AmazonS3Builder::new("wasm-data".into())
+            .credential(AwsCredential {
+                key_id,
+                secret_key,
+                token: None,
+            })
+            .region("ap-southeast-2".into())
+            .sign_payload(true)
+            .build();
+
+        {
+            let mut s3_file = s3.open(&"read-write.txt".into()).await.unwrap();
+
+            let (result, _) = s3_file
+                .write_all(&b"The answer of life, universe and everthing"[..])
+                .await;
+
+            result.unwrap();
+
+            s3_file.close().await.unwrap();
+        }
+        let mut s3_file = s3.open(&"read-write.txt".into()).await.unwrap();
+
+        let size = s3_file.size().await.unwrap();
+        assert_eq!(size, 42);
+        let buf = Vec::new();
+        let (result, buf) = s3_file.read_to_end_at(buf, 0).await;
+        result.unwrap();
+        assert_eq!(buf, b"The answer of life, universe and everthing");
+    }
+}


### PR DESCRIPTION
- Remove dependency on `std::time` under wasm
- Add missing HTTP headers to `WasmClient`


