### PR TITLE
refactor: wrap parquet reader/writer with Arc and Mutex

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,7 +135,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --target wasm32-unknown-unknown --package fusio-parquet --features=wasm
+          args: --target wasm32-unknown-unknown --package fusio-parquet --features=web
 
       - name: Run cargo build on fusio-dispatch
         uses: actions-rs/cargo@v1
@@ -165,4 +165,4 @@ jobs:
       - name: Run wasm-pack test on fusion-parquet
         run: |
           export PATH=$PATH:/tmp/chrome/chrome-linux64/:/tmp/chrome/chromedriver-linux64/
-          wasm-pack test --chrome --headless fusio-parquet --features wasm
+          wasm-pack test --chrome --headless fusio-parquet --features web

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,7 +135,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --target wasm32-unknown-unknown --package fusio-parquet --features=opfs
+          args: --target wasm32-unknown-unknown --package fusio-parquet --features=wasm
 
       - name: Run cargo build on fusio-dispatch
         uses: actions-rs/cargo@v1
@@ -165,4 +165,4 @@ jobs:
       - name: Run wasm-pack test on fusion-parquet
         run: |
           export PATH=$PATH:/tmp/chrome/chrome-linux64/:/tmp/chrome/chromedriver-linux64/
-          wasm-pack test --chrome --headless fusio-parquet --features opfs
+          wasm-pack test --chrome --headless fusio-parquet --features wasm

--- a/examples/opfs/Cargo.toml
+++ b/examples/opfs/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib", "rlib"]
 arrow = "53"
 fusio = { path = "../../fusio", features = ["opfs"] }
 fusio-dispatch = { path = "../../fusio-dispatch", features = ["opfs"] }
-fusio-parquet = { path = "../../fusio-parquet", features = ["wasm"] }
+fusio-parquet = { path = "../../fusio-parquet", features = ["web"] }
 futures = { version = "0.3" }
 parquet = { version = "53", default-features = false, features = [
     "arrow",

--- a/examples/opfs/Cargo.toml
+++ b/examples/opfs/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib", "rlib"]
 arrow = "53"
 fusio = { path = "../../fusio", features = ["opfs"] }
 fusio-dispatch = { path = "../../fusio-dispatch", features = ["opfs"] }
-fusio-parquet = { path = "../../fusio-parquet", features = ["opfs"] }
+fusio-parquet = { path = "../../fusio-parquet", features = ["wasm"] }
 futures = { version = "0.3" }
 parquet = { version = "53", default-features = false, features = [
     "arrow",

--- a/fusio-parquet/Cargo.toml
+++ b/fusio-parquet/Cargo.toml
@@ -8,7 +8,7 @@ version = "0.2.2"
 
 [features]
 default = []
-wasm = ["fusio/opfs"]
+web = ["fusio/opfs"]
 tokio = ["fusio/tokio"]
 
 [dependencies]

--- a/fusio-parquet/Cargo.toml
+++ b/fusio-parquet/Cargo.toml
@@ -8,7 +8,7 @@ version = "0.2.2"
 
 [features]
 default = []
-opfs = ["fusio/opfs"]
+wasm = ["fusio/opfs"]
 tokio = ["fusio/tokio"]
 
 [dependencies]

--- a/fusio-parquet/src/reader.rs
+++ b/fusio-parquet/src/reader.rs
@@ -16,9 +16,9 @@ use parquet::{
 const PREFETCH_FOOTER_SIZE: usize = 512 * 1024;
 
 pub struct AsyncReader {
-    #[cfg(feature = "wasm")]
+    #[cfg(feature = "web")]
     inner: Arc<futures::lock::Mutex<Box<dyn DynFile>>>,
-    #[cfg(not(feature = "wasm"))]
+    #[cfg(not(feature = "web"))]
     inner: Box<dyn DynFile>,
     content_length: u64,
     // The prefetch size for fetching file footer.
@@ -34,7 +34,7 @@ fn set_prefetch_footer_size(footer_size: usize, content_size: u64) -> usize {
 
 impl AsyncReader {
     pub async fn new(reader: Box<dyn DynFile>, content_length: u64) -> Result<Self, fusio::Error> {
-        #[cfg(feature = "wasm")]
+        #[cfg(feature = "web")]
         #[allow(clippy::arc_with_non_send_sync)]
         let reader = Arc::new(futures::lock::Mutex::new(reader));
         Ok(Self {
@@ -57,7 +57,7 @@ impl AsyncFileReader for AsyncReader {
         buf.resize(len, 0);
 
         cfg_if::cfg_if! {
-            if #[cfg(all(feature = "wasm", target_arch = "wasm32"))] {
+            if #[cfg(all(feature = "web", target_arch = "wasm32"))] {
                 let (sender, receiver) = futures::channel::oneshot::channel::<Result<Bytes, ParquetError>>();
 
                 let reader = self.inner.clone();
@@ -97,7 +97,7 @@ impl AsyncFileReader for AsyncReader {
         let content_length = self.content_length;
 
         cfg_if::cfg_if! {
-            if #[cfg(all(feature = "wasm", target_arch = "wasm32"))] {
+            if #[cfg(all(feature = "web", target_arch = "wasm32"))] {
                 let mut buf = BytesMut::with_capacity(footer_size);
                 buf.resize(footer_size, 0);
                 let (sender, receiver) = futures::channel::oneshot::channel::<Result<Arc<ParquetMetaData>, ParquetError>>();

--- a/fusio-parquet/src/writer.rs
+++ b/fusio-parquet/src/writer.rs
@@ -5,17 +5,17 @@ use futures::future::BoxFuture;
 use parquet::{arrow::async_writer::AsyncFileWriter, errors::ParquetError};
 
 pub struct AsyncWriter {
-    #[cfg(feature = "wasm")]
+    #[cfg(feature = "web")]
     #[allow(clippy::arc_with_non_send_sync)]
     inner: Option<std::sync::Arc<futures::lock::Mutex<Box<dyn DynFile>>>>,
-    #[cfg(not(feature = "wasm"))]
+    #[cfg(not(feature = "web"))]
     inner: Option<Box<dyn DynFile>>,
 }
 
 unsafe impl Send for AsyncWriter {}
 impl AsyncWriter {
     pub fn new(writer: Box<dyn DynFile>) -> Self {
-        #[cfg(feature = "wasm")]
+        #[cfg(feature = "web")]
         #[allow(clippy::arc_with_non_send_sync)]
         let writer = std::sync::Arc::new(futures::lock::Mutex::new(writer));
         {
@@ -29,7 +29,7 @@ impl AsyncWriter {
 impl AsyncFileWriter for AsyncWriter {
     fn write(&mut self, bs: Bytes) -> BoxFuture<'_, parquet::errors::Result<()>> {
         cfg_if::cfg_if! {
-            if #[cfg(all(feature = "wasm", target_arch = "wasm32"))] {
+            if #[cfg(all(feature = "web", target_arch = "wasm32"))] {
                 match self.inner.as_mut() {
                     Some(writer) => {
                         let (sender, receiver) = futures::channel::oneshot::channel::<Result<(), ParquetError>>();
@@ -70,7 +70,7 @@ impl AsyncFileWriter for AsyncWriter {
 
     fn complete(&mut self) -> BoxFuture<'_, parquet::errors::Result<()>> {
         cfg_if::cfg_if! {
-            if #[cfg(all(feature = "wasm", target_arch = "wasm32"))] {
+            if #[cfg(all(feature = "web", target_arch = "wasm32"))] {
                  match self.inner.take() {
                     Some(writer) => {
                         let (sender, receiver) = futures::channel::oneshot::channel::<Result<(), ParquetError>>();

--- a/fusio-parquet/tests/wasm.rs
+++ b/fusio-parquet/tests/wasm.rs
@@ -1,5 +1,5 @@
 #[cfg(test)]
-#[cfg(all(feature = "opfs", target_arch = "wasm32"))]
+#[cfg(all(feature = "wasm", target_arch = "wasm32"))]
 pub(crate) mod tests {
 
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);

--- a/fusio-parquet/tests/wasm.rs
+++ b/fusio-parquet/tests/wasm.rs
@@ -1,5 +1,5 @@
 #[cfg(test)]
-#[cfg(all(feature = "wasm", target_arch = "wasm32"))]
+#[cfg(all(feature = "web", target_arch = "wasm32"))]
 pub(crate) mod tests {
 
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);

--- a/fusio/src/impls/disk/opfs/mod.rs
+++ b/fusio/src/impls/disk/opfs/mod.rs
@@ -258,7 +258,6 @@ impl Write for OPFSFile {
         if let Some(writer) = writer {
             JsFuture::from(writer.close()).await.map_err(wasm_err)?;
         }
-        self.file_handle.take();
         Ok(())
     }
 }


### PR DESCRIPTION
wrap parquet reader/writer with `Arc<Mutex>` under wasm to make it works on both `OPFSFile` and `S3File`