### PR TITLE
fix: return full path in opfs list

### DIFF
--- a/fusio/src/impls/disk/opfs/fs.rs
+++ b/fusio/src/impls/disk/opfs/fs.rs
@@ -102,8 +102,8 @@ impl Fs for OPFS {
             .await;
 
         Ok(stream! {
-            for path in entries {
-                yield Ok(FileMeta{ path: path.into(), size: 0 })
+            for entry in entries {
+                yield Ok(FileMeta{ path: path.child(entry), size: 0 })
             }
         })
     }

--- a/fusio/tests/opfs.rs
+++ b/fusio/tests/opfs.rs
@@ -62,7 +62,7 @@ pub(crate) mod tests {
 
         let base_path = Path::from_opfs_path("test_opfs_dir".to_string()).unwrap();
         let mut stream = fs.list(&base_path).await.unwrap();
-        let expected = ["sub_dir", "file"];
+        let expected = ["test_opfs_dir/sub_dir", "test_opfs_dir/file"];
         let mut result_len = 0;
         while let Some(Ok(meta)) = stream.next().await {
             assert!(expected.contains(&meta.path.as_ref()));
@@ -74,7 +74,7 @@ pub(crate) mod tests {
             .await
             .unwrap();
 
-        let expected = ["sub_dir"];
+        let expected = ["test_opfs_dir/sub_dir"];
         let mut result_len = 0;
         let mut stream = fs.list(&base_path).await.unwrap();
         while let Some(Ok(meta)) = stream.next().await {


### PR DESCRIPTION
`FileSystemDirectoryHandle::entries` returns all entries under the directory but only includes filenames. We should return the full path like [std::fs::DirEntry](https://doc.rust-lang.org/nightly/std/fs/struct.DirEntry.html#method.path)

