### PR TITLE
refactor: change close semantic for tokio fs and FileSystemSyncAccessHandle

### DIFF
--- a/fusio/src/dynamic/fs.rs
+++ b/fusio/src/dynamic/fs.rs
@@ -212,9 +212,9 @@ mod tests {
     async fn test_dyn_fs() {
         use tempfile::tempfile;
 
-        use crate::Write;
+        use crate::{disk::tokio::TokioFile, Write};
 
-        let file = tokio::fs::File::from_std(tempfile().unwrap());
+        let file = TokioFile::new(tokio::fs::File::from_std(tempfile().unwrap()));
         let mut dyn_file: Box<dyn super::DynFile> = Box::new(file);
         let buf = [24, 9, 24, 0];
         let (result, _) = dyn_file.write_all(&buf[..]).await;

--- a/fusio/src/impls/disk/tokio/fs.rs
+++ b/fusio/src/impls/disk/tokio/fs.rs
@@ -3,11 +3,12 @@ use std::io;
 use async_stream::stream;
 use futures_core::Stream;
 use tokio::{
-    fs::{create_dir_all, remove_file, File},
+    fs::{create_dir_all, remove_file},
     task::spawn_blocking,
 };
 
 use crate::{
+    disk::tokio::TokioFile,
     fs::{FileMeta, FileSystemTag, Fs, OpenOptions},
     path::{path_to_local, Path},
     Error,
@@ -16,7 +17,7 @@ use crate::{
 pub struct TokioFs;
 
 impl Fs for TokioFs {
-    type File = File;
+    type File = TokioFile;
 
     fn file_system(&self) -> FileSystemTag {
         FileSystemTag::Local
@@ -36,7 +37,7 @@ impl Fs for TokioFs {
             file.set_len(0).await?;
         }
 
-        Ok(file)
+        Ok(TokioFile::new(file))
     }
 
     async fn create_dir_all(path: &Path) -> Result<(), Error> {

--- a/fusio/src/lib.rs
+++ b/fusio/src/lib.rs
@@ -541,10 +541,13 @@ mod tests {
         use tempfile::tempfile;
         use tokio::fs::File;
 
+        use crate::disk::tokio::TokioFile;
+
         let read = tempfile().unwrap();
         let write = read.try_clone().unwrap();
-
-        write_and_read(File::from_std(write), File::from_std(read)).await;
+        let read_file = TokioFile::new(File::from_std(read));
+        let write_file = TokioFile::new(File::from_std(write));
+        write_and_read(write_file, read_file).await;
     }
 
     #[cfg(all(feature = "tokio", not(target_arch = "wasm32")))]
@@ -582,7 +585,9 @@ mod tests {
         use tempfile::tempfile;
         use tokio::fs::File;
 
-        let mut file = File::from_std(tempfile().unwrap());
+        use crate::disk::tokio::TokioFile;
+
+        let mut file = TokioFile::new(File::from_std(tempfile().unwrap()));
         let (result, _) = file.write_all(&b"hello, world"[..]).await;
         result.unwrap();
         let (result, buf) = file.read_exact_at(vec![0u8; 5], 0).await;

--- a/fusio/src/lib.rs
+++ b/fusio/src/lib.rs
@@ -32,9 +32,11 @@
 //! async fn main() {
 //!     #[cfg(feature = "tokio")]
 //!     {
+//!         use fusio::{disk::LocalFs, DynFs};
 //!         use tokio::fs::File;
 //!
-//!         let mut file = File::open("foo.txt").await.unwrap();
+//!         let fs = LocalFs {};
+//!         let mut file = fs.open(&"foo.txt".into()).await.unwrap();
 //!         let write_buf = "hello, world".as_bytes();
 //!         let mut read_buf = [0; 12];
 //!         let (result, _, read_buf) =


### PR DESCRIPTION
#113 

change close semantic to not be able to operate after closing
