### PR TITLE
Feat: append to a file instead of overwriting while opening

### DIFF
--- a/fusio/src/fs/options.rs
+++ b/fusio/src/fs/options.rs
@@ -35,6 +35,7 @@ impl OpenOptions {
     }
 
     pub fn truncate(mut self, truncate: bool) -> Self {
+        self = self.write(true);
         self.truncate = truncate;
         self
     }

--- a/fusio/src/impls/disk/monoio/fs.rs
+++ b/fusio/src/impls/disk/monoio/fs.rs
@@ -21,16 +21,15 @@ impl Fs for MonoIoFs {
 
     async fn open_options(&self, path: &Path, options: OpenOptions) -> Result<Self::File, Error> {
         let local_path = path_to_local(path)?;
-
-        Ok(MonoioFile::from(
-            monoio::fs::OpenOptions::new()
-                .read(options.read)
-                .write(options.write)
-                .create(options.create)
-                .truncate(options.truncate)
-                .open(&local_path)
-                .await?,
-        ))
+        let file = monoio::fs::OpenOptions::new()
+            .read(options.read)
+            .write(options.write)
+            .create(options.create)
+            .truncate(options.truncate)
+            .open(&local_path)
+            .await?;
+        let metadata = file.metadata().await.expect("monoio: get metadat failed");
+        Ok(MonoioFile::new(file, metadata.len()))
     }
 
     async fn create_dir_all(path: &Path) -> Result<(), Error> {

--- a/fusio/src/impls/disk/monoio/fs.rs
+++ b/fusio/src/impls/disk/monoio/fs.rs
@@ -28,7 +28,7 @@ impl Fs for MonoIoFs {
             .truncate(options.truncate)
             .open(&local_path)
             .await?;
-        let metadata = file.metadata().await.expect("monoio: get metadat failed");
+        let metadata = file.metadata().await?;
         Ok(MonoioFile::new(file, metadata.len()))
     }
 

--- a/fusio/src/impls/disk/monoio/mod.rs
+++ b/fusio/src/impls/disk/monoio/mod.rs
@@ -52,6 +52,15 @@ impl From<File> for MonoioFile {
     }
 }
 
+impl MonoioFile {
+    pub(crate) fn new(file: File, pos: u64) -> Self {
+        Self {
+            file: Some(file),
+            pos,
+        }
+    }
+}
+
 impl Write for MonoioFile {
     async fn write_all<B: IoBuf>(&mut self, buf: B) -> (Result<(), Error>, B) {
         let (result, buf) = self

--- a/fusio/src/impls/disk/opfs/fs.rs
+++ b/fusio/src/impls/disk/opfs/fs.rs
@@ -65,9 +65,9 @@ impl Fs for OPFS {
 
         cfg_if::cfg_if! {
             if #[cfg(feature = "sync")] {
-                Ok(Self::File::new(file_handle).await?)
+                Ok(Self::File::new(file_handle, options).await?)
             } else {
-                Ok(OPFSFile::new(file_handle))
+                Ok(OPFSFile::new(file_handle, options).await?)
             }
         }
     }

--- a/fusio/src/impls/disk/opfs/mod.rs
+++ b/fusio/src/impls/disk/opfs/mod.rs
@@ -4,7 +4,7 @@ pub mod fs;
 #[cfg(feature = "sync")]
 pub mod sync;
 
-use std::{io, sync::Arc};
+use std::io;
 
 use js_sys::Uint8Array;
 use wasm_bindgen_futures::JsFuture;
@@ -14,7 +14,7 @@ use web_sys::{
     ReadableStreamReadResult, WorkerGlobalScope,
 };
 
-use crate::{error::wasm_err, Error, IoBuf, IoBufMut, Read, Write};
+use crate::{error::wasm_err, fs::OpenOptions, Error, IoBuf, IoBufMut, Read, Write};
 
 pub(crate) async fn promise<T>(promise: js_sys::Promise) -> Result<T, Error>
 where
@@ -25,198 +25,62 @@ where
     js_val.dyn_into::<T>().map_err(|_obj| Error::CastError)
 }
 
-/// File handle of OPFS file
-pub struct FileHandle {
-    file_handle: FileSystemFileHandle,
-}
-
-impl FileHandle {
-    fn new(file_handle: FileSystemFileHandle) -> Self {
-        Self { file_handle }
-    }
-}
-
-impl FileHandle {
-    /// Attempts to write an entire buffer into the file.
-    ///
-    /// Unlike [`OPFSFile::write_all`], changes will be written to the actual file.
-    pub async fn write_at<B: IoBuf>(&self, buf: B, pos: u64) -> (Result<(), Error>, B) {
-        let options = FileSystemCreateWritableOptions::new();
-        options.set_keep_existing_data(true);
-
-        let writer_promise = self.create_writable_with_options(&options);
-        let writer = match promise::<FileSystemWritableFileStream>(writer_promise).await {
-            Ok(writer) => writer,
-            Err(err) => return (Err(err), buf),
-        };
-
-        if let Err(err) = JsFuture::from(writer.seek_with_u32(pos as u32).unwrap()).await {
-            return (Err(wasm_err(err)), buf);
-        }
-
-        let (result, buf) = self.write_with_stream(buf, &writer).await;
-        if result.is_err() {
-            return (result, buf);
-        }
-        let result = JsFuture::from(writer.close())
-            .await
-            .map_err(wasm_err)
-            .map(|_| ());
-
-        (result, buf)
-    }
-
-    /// Attempts to write an entire buffer into the stream.
-    ///
-    /// No changes are written to the actual file on disk until the stream is closed.
-    async fn write_with_stream<B: IoBuf>(
-        &self,
-        buf: B,
-        stream: &FileSystemWritableFileStream,
-    ) -> (Result<(), Error>, B) {
-        match JsFuture::from(stream.write_with_u8_array(buf.as_slice()).unwrap()).await {
-            Ok(_) => (Ok(()), buf),
-            Err(err) => (Err(wasm_err(err)), buf),
-        }
-    }
-
-    /// Create a `FileSystemWritableFileStream` and return a JavaScript Promise
-    fn create_writable_with_options(
-        &self,
-        options: &FileSystemCreateWritableOptions,
-    ) -> js_sys::Promise {
-        self.file_handle.create_writable_with_options(options)
-    }
-}
-
-impl FileHandle {
-    /// Reads all bytes until EOF in this source, placing them into `buf`.
-    ///
-    /// # Errors
-    ///
-    /// If an error is encountered then the `read_to_end_at` operation
-    /// immediately completes.
-    async fn read_to_end_at(&self, mut buf: Vec<u8>, pos: u64) -> (Result<(), Error>, Vec<u8>) {
-        let file_promise = self.file_handle.get_file();
-        let file = match promise::<File>(file_promise).await {
-            Ok(file) => file,
-            Err(err) => return (Err(err), buf),
-        };
-
-        if (file.size().round() as u64) < pos + buf.bytes_init() as u64 {
-            return (
-                Err(Error::Io(io::Error::new(
-                    io::ErrorKind::UnexpectedEof,
-                    "Read unexpected eof",
-                ))),
-                buf,
-            );
-        }
-
-        let blob = file.slice_with_i32(pos as i32).unwrap();
-        let reader = match blob
-            .stream()
-            .get_reader()
-            .dyn_into::<ReadableStreamDefaultReader>()
-            .map_err(|_obj| Error::CastError)
-        {
-            Ok(reader) => reader,
-            Err(err) => return (Err(err), buf),
-        };
-
-        while let Ok(v) = JsFuture::from(reader.read()).await {
-            let result = ReadableStreamReadResult::from(v);
-            if result.get_done().unwrap() {
-                break;
-            }
-            let chunk = result.get_value().dyn_into::<Uint8Array>().unwrap();
-            buf.extend(chunk.to_vec());
-        }
-
-        (Ok(()), buf)
-    }
-
-    /// Reads the exact number of bytes required to fill `buf` at `pos`.
-    ///
-    /// # Errors
-    ///
-    /// If the operation encounters an "end of file" before completely
-    /// filling the buffer, it returns an error of  [`Error::Io`].
-    pub async fn read_exact_at<B: IoBufMut>(&self, mut buf: B, pos: u64) -> (Result<(), Error>, B) {
-        let buf_len = buf.bytes_init() as i32;
-        let buf_slice = buf.as_slice_mut();
-        let end = pos as i32 + buf_len;
-
-        let file = match promise::<File>(self.file_handle.get_file()).await {
-            Ok(file) => file,
-            Err(err) => return (Err(err), buf),
-        };
-
-        if (file.size().round() as u64) < pos + buf_len as u64 {
-            return (
-                Err(Error::Io(io::Error::new(
-                    io::ErrorKind::UnexpectedEof,
-                    "Read unexpected eof",
-                ))),
-                buf,
-            );
-        }
-        let blob = file.slice_with_i32_and_i32(pos as i32, end).unwrap();
-        let reader = match blob
-            .stream()
-            .get_reader()
-            .dyn_into::<ReadableStreamDefaultReader>()
-            .map_err(|_obj| Error::CastError)
-        {
-            Ok(reader) => reader,
-            Err(err) => return (Err(err), buf),
-        };
-
-        let mut offset = 0;
-        while let Ok(v) = JsFuture::from(reader.read()).await {
-            let result = ReadableStreamReadResult::from(v);
-            if result.get_done().unwrap() {
-                break;
-            }
-
-            let chunk = result.get_value().dyn_into::<Uint8Array>().unwrap();
-            let chunk_len = chunk.length() as usize;
-            buf_slice[offset..offset + chunk_len].copy_from_slice(chunk.to_vec().as_slice());
-            offset += chunk_len;
-        }
-
-        (Ok(()), buf)
-    }
-
-    pub async fn size(&self) -> Result<u64, Error> {
-        let file = promise::<File>(self.file_handle.get_file()).await?;
-
-        Ok(file.size() as u64)
-    }
-}
-
 /// OPFS based on [FileSystemWritableFileStream](https://developer.mozilla.org/en-US/docs/Web/API/FileSystemWritableFileStream)
 pub struct OPFSFile {
-    file_handle: Option<Arc<FileHandle>>,
+    file_handle: FileSystemFileHandle,
     write_stream: Option<FileSystemWritableFileStream>,
-    pos: u32,
+    pos: u64,
 }
 
 impl OPFSFile {
     #[allow(unused)]
-    pub(crate) fn new(file_handle: FileSystemFileHandle) -> Self {
-        Self {
-            file_handle: Some(Arc::new(FileHandle::new(file_handle))),
-            write_stream: None,
-            pos: 0,
-        }
+    pub(crate) async fn new(
+        file_handle: FileSystemFileHandle,
+        open_options: OpenOptions,
+    ) -> Result<Self, Error> {
+        let size = if open_options.truncate {
+            0.0
+        } else {
+            let file = promise::<File>(file_handle.get_file()).await?;
+            file.size()
+        };
+        let write_stream = if open_options.truncate || open_options.write {
+            let options = FileSystemCreateWritableOptions::new();
+            options.set_keep_existing_data(!open_options.truncate);
+
+            let writer_promise = file_handle.create_writable_with_options(&options);
+            let write_stream = promise::<FileSystemWritableFileStream>(writer_promise).await?;
+            JsFuture::from(write_stream.seek_with_f64(size).unwrap())
+                .await
+                .map_err(wasm_err)?;
+
+            Some(write_stream)
+        } else {
+            None
+        };
+
+        Ok(Self {
+            file_handle,
+            write_stream,
+            pos: size.round() as u64,
+        })
     }
 
-    pub fn file_handle(&self) -> Option<Arc<FileHandle>> {
-        match self.file_handle.as_ref() {
-            None => None,
-            Some(file_handle) => Some(Arc::clone(file_handle)),
+    async fn reader(&self, pos: u64, buf_len: u64) -> Result<ReadableStreamDefaultReader, Error> {
+        let file = promise::<File>(self.file_handle.get_file()).await?;
+
+        if (file.size().round() as u64) < pos + buf_len as u64 {
+            return Err(Error::Io(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                "Read unexpected eof",
+            )));
         }
+
+        let blob = file.slice_with_i32(pos as i32).unwrap();
+        blob.stream()
+            .get_reader()
+            .dyn_into::<ReadableStreamDefaultReader>()
+            .map_err(|_obj| Error::CastError)
     }
 }
 
@@ -226,31 +90,22 @@ impl Write for OPFSFile {
     /// No changes are written to the actual file on disk until [`OPFSFile::close`] has been called.
     /// See more detail in [write](https://developer.mozilla.org/en-US/docs/Web/API/FileSystemWritableFileStream/write)
     async fn write_all<B: IoBuf>(&mut self, buf: B) -> (Result<(), Error>, B) {
-        let file_handle = self.file_handle.as_ref().expect("write file after closed");
-        if self.write_stream.is_none() {
-            let options = FileSystemCreateWritableOptions::new();
-            options.set_keep_existing_data(true);
-            let writer_promise = file_handle.create_writable_with_options(&options);
+        debug_assert!(self.write_stream.is_some());
 
-            let writer = match promise::<FileSystemWritableFileStream>(writer_promise).await {
-                Ok(writer) => writer,
-                Err(err) => return (Err(err), buf),
-            };
-
-            if let Err(err) = JsFuture::from(writer.seek_with_u32(self.pos).unwrap())
-                .await
-                .map_err(wasm_err)
-            {
-                return (Err(err), buf);
-            }
-
-            self.write_stream = Some(writer);
-        }
-
-        let writer = self.write_stream.as_ref().unwrap();
         let len = buf.bytes_init();
-        self.pos += len as u32;
-        file_handle.write_with_stream(buf, writer).await
+        self.pos += len as u64;
+        match JsFuture::from(
+            self.write_stream
+                .as_ref()
+                .unwrap()
+                .write_with_u8_array(buf.as_slice())
+                .unwrap(),
+        )
+        .await
+        {
+            Ok(_) => (Ok(()), buf),
+            Err(err) => (Err(wasm_err(err)), buf),
+        }
     }
 
     async fn flush(&mut self) -> Result<(), Error> {
@@ -274,10 +129,29 @@ impl Read for OPFSFile {
     ///
     /// If the operation encounters an "end of file" before completely
     /// filling the buffer, it returns an error of  [`Error::Io`].
-    async fn read_exact_at<B: IoBufMut>(&mut self, buf: B, pos: u64) -> (Result<(), Error>, B) {
-        let file_handle = self.file_handle.as_ref().expect("read file after closed");
+    async fn read_exact_at<B: IoBufMut>(&mut self, mut buf: B, pos: u64) -> (Result<(), Error>, B) {
+        let buf_len = buf.bytes_init() as u64;
+        let buf_slice = buf.as_slice_mut();
 
-        file_handle.read_exact_at(buf, pos).await
+        let reader = match self.reader(pos, buf_len).await {
+            Ok(reader) => reader,
+            Err(err) => return (Err(err), buf),
+        };
+
+        let mut offset = 0;
+        while let Ok(v) = JsFuture::from(reader.read()).await {
+            let result = ReadableStreamReadResult::from(v);
+            if result.get_done().unwrap() {
+                break;
+            }
+
+            let chunk = result.get_value().dyn_into::<Uint8Array>().unwrap();
+            let chunk_len = chunk.length() as usize;
+            buf_slice[offset..offset + chunk_len].copy_from_slice(chunk.to_vec().as_slice());
+            offset += chunk_len;
+        }
+
+        (Ok(()), buf)
     }
 
     /// Reads all bytes until EOF in this source, placing them into `buf`.
@@ -286,16 +160,29 @@ impl Read for OPFSFile {
     ///
     /// If an error is encountered then the `read_to_end_at` operation
     /// immediately completes.
-    async fn read_to_end_at(&mut self, buf: Vec<u8>, pos: u64) -> (Result<(), Error>, Vec<u8>) {
-        let file_handle = self.file_handle.as_ref().expect("read file after closed");
+    async fn read_to_end_at(&mut self, mut buf: Vec<u8>, pos: u64) -> (Result<(), Error>, Vec<u8>) {
+        let reader = match self.reader(pos, 0).await {
+            Ok(reader) => reader,
+            Err(err) => return (Err(err), buf),
+        };
 
-        file_handle.read_to_end_at(buf, pos).await
+        while let Ok(v) = JsFuture::from(reader.read()).await {
+            let result = ReadableStreamReadResult::from(v);
+            if result.get_done().unwrap() {
+                break;
+            }
+            let chunk = result.get_value().dyn_into::<Uint8Array>().unwrap();
+            buf.extend(chunk.to_vec());
+        }
+
+        (Ok(()), buf)
     }
 
     /// Return the size of file in bytes.
     async fn size(&self) -> Result<u64, Error> {
-        let file_handle = self.file_handle.as_ref().expect("read file after closed");
-        file_handle.size().await
+        let file = promise::<File>(self.file_handle.get_file()).await?;
+
+        Ok(file.size() as u64)
     }
 }
 

--- a/fusio/src/impls/disk/opfs/sync/mod.rs
+++ b/fusio/src/impls/disk/opfs/sync/mod.rs
@@ -20,13 +20,17 @@ impl OPFSSyncFile {
     ) -> Result<Self, Error> {
         let js_promise = file_handle.create_sync_access_handle();
         let access_handle = promise::<FileSystemSyncAccessHandle>(js_promise).await?;
+        let mut pos = 0;
+
         if open_options.truncate {
             access_handle.truncate_with_u32(0).map_err(wasm_err)?;
+        } else if open_options.write {
+            pos = access_handle.get_size().map_err(wasm_err)?.round() as u64;
         }
 
         Ok(Self {
             access_handle: Some(access_handle),
-            pos: 0,
+            pos,
         })
     }
 }

--- a/fusio/src/impls/disk/tokio/fs.rs
+++ b/fusio/src/impls/disk/tokio/fs.rs
@@ -29,6 +29,7 @@ impl Fs for TokioFs {
         let file = tokio::fs::OpenOptions::new()
             .read(options.read)
             .write(options.write)
+            .append(options.write)
             .create(options.create)
             .open(&local_path)
             .await?;

--- a/fusio/src/impls/disk/tokio_uring/fs.rs
+++ b/fusio/src/impls/disk/tokio_uring/fs.rs
@@ -30,10 +30,10 @@ impl Fs for TokioUringFs {
             .truncate(options.truncate)
             .open(&local_path)
             .await?;
-
+        let stat = file.statx().await?;
         Ok(TokioUringFile {
             file: Some(file),
-            pos: 0,
+            pos: stat.stx_size,
         })
     }
 

--- a/fusio/src/impls/remotes/aws/fs.rs
+++ b/fusio/src/impls/remotes/aws/fs.rs
@@ -147,7 +147,12 @@ impl Fs for AmazonS3 {
         FileSystemTag::S3
     }
 
-    async fn open_options(&self, path: &Path, _: OpenOptions) -> Result<Self::File, crate::Error> {
+    async fn open_options(&self, path: &Path, options: OpenOptions) -> Result<Self::File, Error> {
+        if options.write && !options.truncate {
+            return Err(Error::Unsupported {
+                message: "Only truncate is supported in S3".to_string(),
+            });
+        }
         Ok(S3File::new(self.clone(), path.clone()))
     }
 

--- a/fusio/src/lib.rs
+++ b/fusio/src/lib.rs
@@ -391,6 +391,9 @@ mod tests {
 
             let (result, buf) = file.read_exact_at(vec![0u8; 12], 0).await;
             result.unwrap();
+            assert_eq!(buf.as_slice(), b"Hello! fusio");
+            let (result, buf) = file.read_exact_at(vec![0u8; 12], 12).await;
+            result.unwrap();
             assert_eq!(buf.as_slice(), b"Hello! world");
         }
 
@@ -467,6 +470,9 @@ mod tests {
 
             let (result, buf) = src_file.read_exact_at(vec![0u8; 12], 0).await;
             result.unwrap();
+            assert_eq!(buf.as_slice(), b"Hello! fusio");
+            let (result, buf) = src_file.read_exact_at(vec![0u8; 12], 12).await;
+            result.unwrap();
             assert_eq!(buf.as_slice(), b"Hello! world");
 
             let mut dst_file = src_fs
@@ -476,7 +482,7 @@ mod tests {
                 )
                 .await?;
 
-            let (result, buf) = dst_file.read_exact_at(vec![0u8; 12], 0).await;
+            let (result, buf) = dst_file.read_to_end_at(vec![], 0).await;
             result.unwrap();
             assert_eq!(buf.as_slice(), b"Hello! fusio");
         }
@@ -520,6 +526,9 @@ mod tests {
                 .await?;
             let (result, buf) = src_file.read_exact_at(vec![0u8; 12], 0).await;
             result.unwrap();
+            assert_eq!(buf.as_slice(), b"Hello! fusio");
+            let (result, buf) = src_file.read_exact_at(vec![0u8; 12], 12).await;
+            result.unwrap();
             assert_eq!(buf.as_slice(), b"Hello! world");
 
             let mut dst_file = src_fs
@@ -530,6 +539,9 @@ mod tests {
                 .await?;
 
             let (result, buf) = dst_file.read_exact_at(vec![0u8; 12], 0).await;
+            result.unwrap();
+            assert_eq!(buf.as_slice(), b"Hello! fusio");
+            let (result, buf) = src_file.read_exact_at(vec![0u8; 12], 12).await;
             result.unwrap();
             assert_eq!(buf.as_slice(), b"Hello! world");
         }

--- a/fusio/tests/opfs.rs
+++ b/fusio/tests/opfs.rs
@@ -4,7 +4,7 @@ pub(crate) mod tests {
 
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
-    use fusio::{disk::OPFS, dynamic::DynFile, fs::OpenOptions, path::Path, DynFs, Read, Write};
+    use fusio::{disk::OPFS, fs::OpenOptions, path::Path, DynFs, Read, Write};
     use futures_util::StreamExt;
     use wasm_bindgen_test::wasm_bindgen_test;
 
@@ -90,7 +90,7 @@ pub(crate) mod tests {
     async fn test_opfs_read_write() {
         let fs = OPFS;
         let mut file = fs
-            .open_options(&"file".into(), OpenOptions::default().create(true))
+            .open_options(&"file_rw".into(), OpenOptions::default().create(true).truncate(true))
             .await
             .unwrap();
         let (result, _) = file.write_all([1, 2, 3, 4].as_mut()).await;
@@ -102,7 +102,7 @@ pub(crate) mod tests {
         file.close().await.unwrap();
 
         let mut file = fs
-            .open_options(&"file".into(), OpenOptions::default().create(true))
+            .open_options(&"file_rw".into(), OpenOptions::default().create(true))
             .await
             .unwrap();
         let expected = [1_u8, 2, 3, 4, 11, 23, 34, 47, 121, 93, 94, 97];
@@ -116,14 +116,14 @@ pub(crate) mod tests {
         let (result, data) = file.read_exact_at(buf.as_mut(), 3).await;
         result.unwrap();
         assert_eq!(data, [4, 11, 23, 34, 47, 121, 93]);
-        remove_all(&fs, &["file"]).await;
+        remove_all(&fs, &["file_rw"]).await;
     }
 
     #[wasm_bindgen_test]
     async fn test_opfs_read_write_utf16() {
         let fs = OPFS;
         let mut file = fs
-            .open_options(&"file".into(), OpenOptions::default().create(true))
+            .open_options(&"file_utf16".into(), OpenOptions::default().create(true).truncate(true))
             .await
             .unwrap();
         let utf16_bytes: &[u8] = &[
@@ -136,7 +136,7 @@ pub(crate) mod tests {
         file.close().await.unwrap();
 
         let mut file = fs
-            .open_options(&"file".into(), OpenOptions::default().create(true))
+            .open_options(&"file_utf16".into(), OpenOptions::default().write(true))
             .await
             .unwrap();
         let (result, data) = file.read_to_end_at(vec![], 0).await;
@@ -149,49 +149,14 @@ pub(crate) mod tests {
             ]
         );
 
-        remove_all(&fs, &["file"]).await;
-    }
-
-    #[wasm_bindgen_test]
-    async fn test_opfs_handle_write() {
-        let fs = OPFS;
-        let mut file = fs
-            .open_options(&"file".into(), OpenOptions::default().create(true))
-            .await
-            .unwrap();
-        let opfs =
-            unsafe { std::mem::transmute::<&Box<dyn DynFile>, &Box<fusio::disk::OPFSFile>>(&file) };
-
-        let handle = opfs.file_handle().unwrap();
-
-        let (result, _) = handle.write_at([1, 2, 3, 4].as_mut(), 0).await;
-        result.unwrap();
-        let (result, _) = handle.write_at([11, 23, 34, 47].as_mut(), 4).await;
-        result.unwrap();
-        let (result, _) = handle.write_at([121, 93, 94, 97].as_mut(), 8).await;
-        result.unwrap();
-        file.close().await.unwrap();
-
-        let file = fs
-            .open_options(&"file".into(), OpenOptions::default().create(true))
-            .await
-            .unwrap();
-        let opfs =
-            unsafe { std::mem::transmute::<&Box<dyn DynFile>, &Box<fusio::disk::OPFSFile>>(&file) };
-        let handle = opfs.file_handle().unwrap();
-        let mut buf = [0; 7];
-
-        let (result, data) = handle.read_exact_at(buf.as_mut(), 3).await;
-        result.unwrap();
-        assert_eq!(data, [4, 11, 23, 34, 47, 121, 93]);
-        remove_all(&fs, &["file"]).await;
+        remove_all(&fs, &["file_utf16"]).await;
     }
 
     #[wasm_bindgen_test]
     async fn test_opfs_read_eof() {
         let fs = OPFS;
         let mut file = fs
-            .open_options(&"file".into(), OpenOptions::default().create(true))
+            .open_options(&"file_eof".into(), OpenOptions::default().create(true).truncate(true))
             .await
             .unwrap();
 
@@ -204,7 +169,7 @@ pub(crate) mod tests {
         file.close().await.unwrap();
 
         let mut file = fs
-            .open_options(&"file".into(), OpenOptions::default().create(true))
+            .open_options(&"file_eof".into(), OpenOptions::default().write(true))
             .await
             .unwrap();
 
@@ -212,6 +177,6 @@ pub(crate) mod tests {
         let (result, data) = file.read_exact_at(buf.as_mut(), 5).await;
         assert!(result.is_err());
         assert_eq!(data, [0]);
-        remove_all(&fs, &["file"]).await;
+        remove_all(&fs, &["file_eof"]).await;
     }
 }


### PR DESCRIPTION
- append to a file instead of overwriting while opening for disk based file(tokio file, opfs, monoio and tokio_uring)
- remove FileHandle struct in OPFS