### PR TITLE
chore: bump arrow and parquet to 54

### DIFF
--- a/examples/opfs/Cargo.toml
+++ b/examples/opfs/Cargo.toml
@@ -8,12 +8,12 @@ version = "0.1.0"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-arrow = "53"
+arrow = "54"
 fusio = { path = "../../fusio", features = ["opfs"] }
 fusio-dispatch = { path = "../../fusio-dispatch", features = ["opfs"] }
 fusio-parquet = { path = "../../fusio-parquet", features = ["web"] }
 futures = { version = "0.3" }
-parquet = { version = "53", default-features = false, features = [
+parquet = { version = "54", default-features = false, features = [
     "arrow",
     "async",
 ] }

--- a/fusio-object-store/Cargo.toml
+++ b/fusio-object-store/Cargo.toml
@@ -17,7 +17,7 @@ fusio = { version = "0.3.4", path = "../fusio", features = [
 futures-core = { version = "0.3" }
 futures-util = { version = "0.3" }
 object_store = { version = "0.11" }
-parquet = { version = "53.1.0", features = ["async", "object_store"] }
+parquet = { version = "54", features = ["async", "object_store"] }
 tokio = { version = "1", features = ["full"] }
 
 [dev-dependencies]

--- a/fusio-parquet/Cargo.toml
+++ b/fusio-parquet/Cargo.toml
@@ -16,7 +16,7 @@ bytes = { workspace = true }
 cfg-if = "1.0.0"
 fusio = { version = "0.3.4", path = "../fusio", features = ["bytes", "dyn"] }
 futures = { version = "0.3" }
-parquet = { version = "53", default-features = false, features = [
+parquet = { version = "54", default-features = false, features = [
     "arrow",
     "async",
 ] }
@@ -25,7 +25,7 @@ parquet = { version = "53", default-features = false, features = [
 wasm-bindgen-futures = { version = "0.4.45" }
 
 [dev-dependencies]
-arrow = "53"
+arrow = "54"
 rand = "0.8"
 tempfile = "3.12.0"
 tokio = { version = "1.40" }


### PR DESCRIPTION
This is needed for TonboDB to upgrade arrow and parquet to 54.