### PR TITLE
fix: set write to true only when create is true

### DIFF
--- a/fusio/src/fs/options.rs
+++ b/fusio/src/fs/options.rs
@@ -29,8 +29,10 @@ impl OpenOptions {
     }
 
     pub fn create(mut self, create: bool) -> Self {
-        self = self.write(true);
         self.create = create;
+        if create {
+            self.write = true;
+        }
         self
     }
 


### PR DESCRIPTION
I think `OpenOptions::create(bool)` should set write to true only when create is true