### PR TITLE
fix: remove append option in tokio

### DIFF
--- a/fusio/src/dynamic/fs.rs
+++ b/fusio/src/dynamic/fs.rs
@@ -214,7 +214,7 @@ mod tests {
 
         use crate::{disk::tokio::TokioFile, Write};
 
-        let file = TokioFile::new(tokio::fs::File::from_std(tempfile().unwrap()));
+        let file = TokioFile::new(tokio::fs::File::from_std(tempfile().unwrap()), 0);
         let mut dyn_file: Box<dyn super::DynFile> = Box::new(file);
         let buf = [24, 9, 24, 0];
         let (result, _) = dyn_file.write_all(&buf[..]).await;

--- a/fusio/src/impls/buffered.rs
+++ b/fusio/src/impls/buffered.rs
@@ -181,7 +181,7 @@ pub(crate) mod tests {
 
         use crate::disk::tokio::TokioFile;
 
-        let mut file = TokioFile::new(tokio::fs::File::from_std(tempfile().unwrap()));
+        let mut file = TokioFile::new(tokio::fs::File::from_std(tempfile().unwrap()), 0);
         let _ = file
             .write_all([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15].as_slice())
             .await;
@@ -235,7 +235,7 @@ pub(crate) mod tests {
             Read, Write,
         };
 
-        let file = TokioFile::new(tokio::fs::File::from_std(tempfile().unwrap()));
+        let file = TokioFile::new(tokio::fs::File::from_std(tempfile().unwrap()), 0);
         let mut writer = BufWriter::new(file, 4);
         {
             let _ = writer.write_all("Hello".as_bytes()).await;

--- a/fusio/src/impls/disk/tokio/fs.rs
+++ b/fusio/src/impls/disk/tokio/fs.rs
@@ -29,16 +29,17 @@ impl Fs for TokioFs {
         let file = tokio::fs::OpenOptions::new()
             .read(options.read)
             .write(options.write)
-            .append(options.write)
             .create(options.create)
             .open(&local_path)
             .await?;
 
-        if options.truncate {
-            file.set_len(0).await?;
-        }
+        let pos = if options.truncate {
+            0
+        } else {
+            file.metadata().await?.len()
+        };
 
-        Ok(TokioFile::new(file))
+        Ok(TokioFile::new(file, pos))
     }
 
     async fn create_dir_all(path: &Path) -> Result<(), Error> {

--- a/fusio/src/lib.rs
+++ b/fusio/src/lib.rs
@@ -559,8 +559,8 @@ mod tests {
 
         let read = tempfile().unwrap();
         let write = read.try_clone().unwrap();
-        let read_file = TokioFile::new(File::from_std(read));
-        let write_file = TokioFile::new(File::from_std(write));
+        let read_file = TokioFile::new(File::from_std(read), 0);
+        let write_file = TokioFile::new(File::from_std(write), 0);
         write_and_read(write_file, read_file).await;
     }
 
@@ -601,7 +601,7 @@ mod tests {
 
         use crate::disk::tokio::TokioFile;
 
-        let mut file = TokioFile::new(File::from_std(tempfile().unwrap()));
+        let mut file = TokioFile::new(File::from_std(tempfile().unwrap()), 0);
         let (result, _) = file.write_all(&b"hello, world"[..]).await;
         result.unwrap();
         let (result, buf) = file.read_exact_at(vec![0u8; 5], 0).await;


### PR DESCRIPTION
write will be ignored in append mod, and it will cause error when using `set_len` in windows. So we should manage file position by ourselves.