### PR TITLE
bump fusio to 0.3.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ resolver = "2"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/tonbo-io/fusio"
-version = "0.3.7"
+version = "0.3.8"
 
 [workspace.dependencies]
 bytes = { version = "1.7" }

--- a/fusio-dispatch/Cargo.toml
+++ b/fusio-dispatch/Cargo.toml
@@ -15,6 +15,6 @@ opfs = ["fusio/opfs"]
 tokio = ["fusio/tokio"]
 
 [dependencies]
-fusio = { version = "0.3.4", path = "../fusio" }
-fusio-object-store = { version = "0.3.4", path = "../fusio-object-store", optional = true }
+fusio = { version = "0.3.8", path = "../fusio" }
+fusio-object-store = { version = "0.3.8", path = "../fusio-object-store", optional = true }
 object_store = { version = "0.11", optional = true }

--- a/fusio-log/Cargo.toml
+++ b/fusio-log/Cargo.toml
@@ -23,15 +23,15 @@ web-http = ["fusio/wasm-http"]
 [dependencies]
 bytes = { workspace = true, optional = true }
 crc32fast = "1"
-fusio = { version = "0.3.7", path = "../fusio", features = [
+fusio = { version = "0.3.8", path = "../fusio", features = [
     "dyn",
     "fs",
     "bytes",
 ] }
-fusio-dispatch = { version = "0.3.7", path = "../fusio-dispatch" }
+fusio-dispatch = { version = "0.3.8", path = "../fusio-dispatch" }
 futures-core = "0.3"
 futures-util = "0.3"
-thiserror = "2.0.3"
+thiserror = "2.0.12"
 
 [dev-dependencies]
 tempfile = "3"

--- a/fusio-object-store/Cargo.toml
+++ b/fusio-object-store/Cargo.toml
@@ -8,7 +8,7 @@ version.workspace = true
 
 [dependencies]
 async-stream = { version = "0.3" }
-fusio = { version = "0.3.4", path = "../fusio", features = [
+fusio = { version = "0.3.8", path = "../fusio", features = [
     "bytes",
     "dyn",
     "object_store",

--- a/fusio-opendal/Cargo.toml
+++ b/fusio-opendal/Cargo.toml
@@ -7,7 +7,7 @@ repository.workspace = true
 version.workspace = true
 
 [dependencies]
-fusio = { version = "0.3.4", path = "../fusio", features = ["bytes"] }
+fusio = { version = "0.3.8", path = "../fusio", features = ["bytes"] }
 futures-core = { version = "0.3" }
 futures-util = { version = "0.3" }
 opendal = { version = "0.50.1", default-features = false }

--- a/fusio-parquet/Cargo.toml
+++ b/fusio-parquet/Cargo.toml
@@ -34,7 +34,7 @@ required-features = ["bench", "tokio"]
 [dependencies]
 bytes = { workspace = true }
 cfg-if = "1.0.0"
-fusio = { version = "0.3.4", path = "../fusio", features = ["bytes", "dyn"] }
+fusio = { version = "0.3.8", path = "../fusio", features = ["bytes", "dyn"] }
 futures = { version = "0.3" }
 monoio = { version = "0.2", optional = true, features = ["sync"] }
 parquet = { version = "54", default-features = false, features = [

--- a/fusio-parquet/src/reader.rs
+++ b/fusio-parquet/src/reader.rs
@@ -145,7 +145,7 @@ impl AsyncFileReader for AsyncReader {
                         let buf = &prefetched_footer_slice
                             [(prefetched_footer_length - FOOTER_SIZE)..prefetched_footer_length];
                         debug_assert!(buf.len() == FOOTER_SIZE);
-                        ParquetMetaDataReader::decode_footer(buf.try_into().unwrap()).unwrap()
+                        ParquetMetaDataReader::decode_footer_tail(buf.try_into().unwrap()).unwrap().metadata_length()
                     };
 
                     // Try to read the metadata from the `prefetched_footer_content`.
@@ -204,7 +204,7 @@ impl AsyncFileReader for AsyncReader {
                         let buf = &prefetched_footer_slice
                             [(prefetched_footer_length - FOOTER_SIZE)..prefetched_footer_length];
                         debug_assert!(buf.len() == FOOTER_SIZE);
-                        ParquetMetaDataReader::decode_footer(buf.try_into().unwrap()).unwrap()
+                        ParquetMetaDataReader::decode_footer_tail(buf.try_into().unwrap()).unwrap().metadata_length()
                     };
 
                     // Try to read the metadata from the `prefetched_footer_content`.
@@ -247,7 +247,7 @@ impl AsyncFileReader for AsyncReader {
                         let buf = &prefetched_footer_slice
                             [(prefetched_footer_length - FOOTER_SIZE)..prefetched_footer_length];
                         debug_assert!(buf.len() == FOOTER_SIZE);
-                        ParquetMetaDataReader::decode_footer(buf.try_into().unwrap())?
+                        ParquetMetaDataReader::decode_footer_tail(buf.try_into().unwrap())?.metadata_length()
                     };
 
                     // Try to read the metadata from the `prefetched_footer_content`.

--- a/fusio/Cargo.toml
+++ b/fusio/Cargo.toml
@@ -77,7 +77,7 @@ chrono = { version = "0.4", optional = true, default-features = false, features 
     "std",
     "wasmbind",
 ] }
-fusio-core = { path = "../fusio-core" }
+fusio-core = { path = "../fusio-core", version = "0.3.8" }
 futures-core = { version = "0.3" }
 futures-util = { version = "0.3" }
 http = { version = "1", optional = true, default-features = false }
@@ -100,7 +100,7 @@ ring = { version = "0.17", optional = true, default-features = false, features =
 serde = { version = "1", optional = true, features = ["derive"] }
 serde_json = { version = "1", optional = true }
 serde_urlencoded = { version = "0.7", optional = true }
-thiserror = "1"
+thiserror = "2.0.12"
 tokio = { version = "1", optional = true, default-features = false, features = [
     "io-util",
     "rt-multi-thread",


### PR DESCRIPTION
- replace `ParquetMetaDataReader::decode_footer` with `ParquetMetaDataReader::decode_footer_tail` due to being deprecated
- bump fusio to 0.3.8

