### PR TITLE
refactor: remove associated type in encode/decode

### DIFF
--- a/fusio-log/src/lib.rs
+++ b/fusio-log/src/lib.rs
@@ -199,6 +199,7 @@ mod tests {
 
     use std::pin::pin;
 
+    use fusio::Error;
     use futures_util::{StreamExt, TryStreamExt};
     use tempfile::TempDir;
 
@@ -215,9 +216,7 @@ mod tests {
     }
 
     impl Encode for TestStruct {
-        type Error = fusio::Error;
-
-        async fn encode<W>(&self, writer: &mut W) -> Result<(), Self::Error>
+        async fn encode<W>(&self, writer: &mut W) -> Result<(), Error>
         where
             W: Write,
         {
@@ -233,9 +232,7 @@ mod tests {
     }
 
     impl Decode for TestStruct {
-        type Error = fusio::Error;
-
-        async fn decode<R>(reader: &mut R) -> Result<Self, Self::Error>
+        async fn decode<R>(reader: &mut R) -> Result<Self, Error>
         where
             R: SeqRead,
         {

--- a/fusio-log/src/serdes/arc.rs
+++ b/fusio-log/src/serdes/arc.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use fusio::{SeqRead, Write};
+use fusio::{Error, SeqRead, Write};
 
 use super::{Decode, Encode};
 
@@ -8,9 +8,7 @@ impl<T> Decode for Arc<T>
 where
     T: Decode,
 {
-    type Error = T::Error;
-
-    async fn decode<R>(reader: &mut R) -> Result<Self, Self::Error>
+    async fn decode<R>(reader: &mut R) -> Result<Self, Error>
     where
         R: SeqRead,
     {
@@ -22,9 +20,7 @@ impl<T> Encode for Arc<T>
 where
     T: Encode + Send + Sync,
 {
-    type Error = T::Error;
-
-    async fn encode<W>(&self, writer: &mut W) -> Result<(), Self::Error>
+    async fn encode<W>(&self, writer: &mut W) -> Result<(), Error>
     where
         W: Write,
     {

--- a/fusio-log/src/serdes/boolean.rs
+++ b/fusio-log/src/serdes/boolean.rs
@@ -1,13 +1,11 @@
 use std::mem::size_of;
 
-use fusio::{SeqRead, Write};
+use fusio::{Error, SeqRead, Write};
 
 use crate::serdes::{Decode, Encode};
 
 impl Encode for bool {
-    type Error = fusio::Error;
-
-    async fn encode<W: Write>(&self, writer: &mut W) -> Result<(), Self::Error> {
+    async fn encode<W: Write>(&self, writer: &mut W) -> Result<(), Error> {
         if *self { 1u8 } else { 0u8 }.encode(writer).await
     }
 
@@ -17,9 +15,7 @@ impl Encode for bool {
 }
 
 impl Decode for bool {
-    type Error = fusio::Error;
-
-    async fn decode<R: SeqRead>(reader: &mut R) -> Result<Self, Self::Error> {
+    async fn decode<R: SeqRead>(reader: &mut R) -> Result<Self, Error> {
         Ok(u8::decode(reader).await? == 1u8)
     }
 }

--- a/fusio-log/src/serdes/bytes.rs
+++ b/fusio-log/src/serdes/bytes.rs
@@ -1,12 +1,10 @@
 use bytes::Bytes;
-use fusio::{IoBuf, SeqRead, Write};
+use fusio::{Error, IoBuf, SeqRead, Write};
 
 use crate::serdes::{Decode, Encode};
 
 impl Encode for &[u8] {
-    type Error = fusio::Error;
-
-    async fn encode<W: Write>(&self, writer: &mut W) -> Result<(), Self::Error> {
+    async fn encode<W: Write>(&self, writer: &mut W) -> Result<(), Error> {
         (self.len() as u32).encode(writer).await?;
         #[cfg(feature = "monoio")]
         let (result, _) = writer.write_all(self.to_vec()).await;
@@ -23,9 +21,7 @@ impl Encode for &[u8] {
 }
 
 impl Encode for Bytes {
-    type Error = fusio::Error;
-
-    async fn encode<W: Write>(&self, writer: &mut W) -> Result<(), Self::Error> {
+    async fn encode<W: Write>(&self, writer: &mut W) -> Result<(), Error> {
         (self.len() as u32).encode(writer).await?;
         #[cfg(feature = "monoio")]
         let (result, _) = writer.write_all(self.as_bytes()).await;
@@ -42,9 +38,7 @@ impl Encode for Bytes {
 }
 
 impl Decode for Bytes {
-    type Error = fusio::Error;
-
-    async fn decode<R: SeqRead>(reader: &mut R) -> Result<Self, Self::Error> {
+    async fn decode<R: SeqRead>(reader: &mut R) -> Result<Self, Error> {
         let len = u32::decode(reader).await?;
         let (result, buf) = reader.read_exact(vec![0u8; len as usize]).await;
         result?;

--- a/fusio-log/src/serdes/num.rs
+++ b/fusio-log/src/serdes/num.rs
@@ -1,6 +1,6 @@
 use std::mem::size_of;
 
-use fusio::{SeqRead, Write};
+use fusio::{Error, SeqRead, Write};
 
 use super::{Decode, Encode};
 
@@ -8,9 +8,7 @@ use super::{Decode, Encode};
 macro_rules! implement_encode_decode {
     ($struct_name:ident) => {
         impl Encode for $struct_name {
-            type Error = fusio::Error;
-
-            async fn encode<W: Write>(&self, writer: &mut W) -> Result<(), Self::Error> {
+            async fn encode<W: Write>(&self, writer: &mut W) -> Result<(), Error> {
                 #[cfg(feature = "monoio")]
                 let (result, _) = writer.write_all(self.to_le_bytes().to_vec()).await;
                 #[cfg(not(feature = "monoio"))]
@@ -26,9 +24,7 @@ macro_rules! implement_encode_decode {
         }
 
         impl Decode for $struct_name {
-            type Error = fusio::Error;
-
-            async fn decode<R: SeqRead>(reader: &mut R) -> Result<Self, Self::Error> {
+            async fn decode<R: SeqRead>(reader: &mut R) -> Result<Self, Error> {
                 #[cfg(feature = "monoio")]
                 let data = {
                     let (result, buf) = reader.read_exact(vec![0u8; size_of::<Self>()]).await;

--- a/fusio-log/src/serdes/string.rs
+++ b/fusio-log/src/serdes/string.rs
@@ -1,13 +1,11 @@
 use std::mem::size_of;
 
-use fusio::{SeqRead, Write};
+use fusio::{Error, SeqRead, Write};
 
 use super::{Decode, Encode};
 
 impl Encode for &str {
-    type Error = fusio::Error;
-
-    async fn encode<W>(&self, writer: &mut W) -> Result<(), Self::Error>
+    async fn encode<W>(&self, writer: &mut W) -> Result<(), Error>
     where
         W: Write,
     {
@@ -27,9 +25,7 @@ impl Encode for &str {
 }
 
 impl Encode for String {
-    type Error = fusio::Error;
-
-    async fn encode<W>(&self, writer: &mut W) -> Result<(), Self::Error>
+    async fn encode<W>(&self, writer: &mut W) -> Result<(), Error>
     where
         W: Write,
     {
@@ -42,9 +38,7 @@ impl Encode for String {
 }
 
 impl Decode for String {
-    type Error = fusio::Error;
-
-    async fn decode<R: SeqRead>(reader: &mut R) -> Result<Self, Self::Error> {
+    async fn decode<R: SeqRead>(reader: &mut R) -> Result<Self, Error> {
         let len = u16::decode(reader).await?;
         let (result, buf) = reader.read_exact(vec![0u8; len as usize]).await;
         result?;


### PR DESCRIPTION
_https://github.com/tonbo-io/fusio/issues/183#issuecomment-3007384319_
> IMO if we remove associated type, and make encode & decode return fusio::Error, the error handling could be simplified

