### PR TITLE
feat: add executor feature

### DIFF
--- a/fusio/Cargo.toml
+++ b/fusio/Cargo.toml
@@ -27,7 +27,7 @@ aws = [
 ]
 bytes = ["dep:bytes", "fusio-core/bytes"]
 completion-based = ["fusio-core/completion-based"]
-default = ["dyn", "fs"]
+default = ["dyn", "fs", "executor"]
 dyn = ["fusio-core/alloc"]
 fs = ["tokio?/fs", "tokio?/rt"]
 http = [
@@ -45,7 +45,9 @@ monoio-http = ["http", "dep:monoio-http-client", "dep:monoio-http", "monoio"]
 no-send = ["fusio-core/no-send"]
 opfs = [
     "async-stream",
+    "dep:async-lock",
     "dep:js-sys",
+    "dep:wasm-bindgen",
     "dep:wasm-bindgen-futures",
     "dep:web-sys",
     "no-send",
@@ -55,6 +57,8 @@ tokio = ["async-stream", "dep:tokio"]
 tokio-http = ["dep:reqwest", "http", "tokio"]
 tokio-uring = ["async-stream", "completion-based", "dep:tokio-uring", "no-send"]
 wasm-http = ["dep:reqwest", "http"]
+executor = []
+executor-tokio = ["executor", "tokio", "tokio/sync", "tokio/rt"]
 
 [[bench]]
 harness = false
@@ -136,6 +140,8 @@ web-sys = { version = "0.3", optional = true, features = [
     "WorkerNavigator",
 
 ] }
+async-lock = { version = "3", optional = true }
+wasm-bindgen = { version = "0.2.95", optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 tokio-uring = { version = "0.5", default-features = false, optional = true }

--- a/fusio/src/executor/mod.rs
+++ b/fusio/src/executor/mod.rs
@@ -1,0 +1,74 @@
+use std::{
+    error::Error,
+    future::Future,
+    ops::{Deref, DerefMut},
+};
+
+use fusio_core::{MaybeSend, MaybeSendFuture, MaybeSync};
+
+pub trait JoinHandle<R> {
+    fn join(self) -> impl Future<Output = Result<R, Box<dyn Error>>> + MaybeSend;
+}
+
+pub trait RwLock<T> {
+    type ReadGuard<'a>: Deref<Target = T> + MaybeSend + 'a
+    where
+        Self: 'a;
+
+    type WriteGuard<'a>: DerefMut<Target = T> + MaybeSend + 'a
+    where
+        Self: 'a;
+
+    fn read(&self) -> impl Future<Output = Self::ReadGuard<'_>> + MaybeSend;
+
+    fn write(&self) -> impl Future<Output = Self::WriteGuard<'_>> + MaybeSend;
+}
+
+pub trait Executor: 'static {
+    type JoinHandle<R>: JoinHandle<R>
+    where
+        R: MaybeSend;
+
+    type RwLock<T>: RwLock<T> + MaybeSend + MaybeSync
+    where
+        T: MaybeSend + MaybeSync;
+
+    fn spawn<F>(&self, future: F) -> Self::JoinHandle<F::Output>
+    where
+        F: Future + MaybeSend + 'static,
+        F::Output: MaybeSend;
+
+    fn rw_lock<T>(value: T) -> Self::RwLock<T>
+    where
+        T: MaybeSend + MaybeSync;
+}
+
+#[cfg(feature = "executor-tokio")]
+pub mod tokio;
+
+/// Minimal timer abstraction to decouple libraries from concrete runtimes.
+pub trait Sleeper: MaybeSend + MaybeSync {
+    /// Sleep for the given duration and yield back to the runtime.
+    fn sleep(
+        &self,
+        dur: core::time::Duration,
+    ) -> core::pin::Pin<Box<dyn MaybeSendFuture<Output = ()>>>;
+}
+
+/// A blocking fallback for environments without an async runtime.
+#[cfg(not(target_arch = "wasm32"))]
+#[derive(Debug, Default, Clone, Copy)]
+pub struct BlockingSleeper;
+
+#[cfg(not(target_arch = "wasm32"))]
+impl Sleeper for BlockingSleeper {
+    fn sleep(
+        &self,
+        dur: core::time::Duration,
+    ) -> core::pin::Pin<Box<dyn MaybeSendFuture<Output = ()>>> {
+        Box::pin(async move { std::thread::sleep(dur) })
+    }
+}
+
+#[cfg(all(feature = "opfs", target_arch = "wasm32"))]
+pub mod opfs;

--- a/fusio/src/executor/opfs.rs
+++ b/fusio/src/executor/opfs.rs
@@ -1,0 +1,113 @@
+use std::{error::Error, future::Future, sync::Arc};
+
+use fusio_core::{MaybeSend, MaybeSendFuture, MaybeSync};
+use wasm_bindgen::{prelude::*, JsCast};
+
+use super::{Executor, JoinHandle, RwLock, Sleeper};
+
+#[wasm_bindgen]
+pub struct OpfsExecutor;
+
+impl Default for OpfsExecutor {
+    fn default() -> Self {
+        Self
+    }
+}
+
+impl OpfsExecutor {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+pub struct OpfsJoinHandle<R> {
+    _phantom: core::marker::PhantomData<R>,
+}
+
+impl<R> JoinHandle<R> for OpfsJoinHandle<R>
+where
+    R: MaybeSend,
+{
+    async fn join(self) -> Result<R, Box<dyn Error>> {
+        // In WASM spawn_local has no join handle; document limitation.
+        Err("Cannot join spawned tasks in WASM".into())
+    }
+}
+
+impl<T> RwLock<T> for Arc<async_lock::RwLock<T>>
+where
+    T: MaybeSend + MaybeSync,
+{
+    type ReadGuard<'a>
+        = async_lock::RwLockReadGuard<'a, T>
+    where
+        Self: 'a;
+
+    type WriteGuard<'a>
+        = async_lock::RwLockWriteGuard<'a, T>
+    where
+        Self: 'a;
+
+    async fn read(&self) -> Self::ReadGuard<'_> {
+        async_lock::RwLock::read(self).await
+    }
+
+    async fn write(&self) -> Self::WriteGuard<'_> {
+        async_lock::RwLock::write(self).await
+    }
+}
+
+impl Executor for OpfsExecutor {
+    type JoinHandle<R>
+        = OpfsJoinHandle<R>
+    where
+        R: MaybeSend;
+
+    type RwLock<T>
+        = Arc<async_lock::RwLock<T>>
+    where
+        T: MaybeSend + MaybeSync;
+
+    fn spawn<F>(&self, future: F) -> Self::JoinHandle<F::Output>
+    where
+        F: Future + MaybeSend + 'static,
+        F::Output: MaybeSend,
+    {
+        wasm_bindgen_futures::spawn_local(async move {
+            let _ = future.await;
+        });
+        OpfsJoinHandle {
+            _phantom: core::marker::PhantomData,
+        }
+    }
+
+    fn rw_lock<T>(value: T) -> Self::RwLock<T>
+    where
+        T: MaybeSend + MaybeSync,
+    {
+        Arc::new(async_lock::RwLock::new(value))
+    }
+}
+
+impl Sleeper for OpfsExecutor {
+    fn sleep(
+        &self,
+        dur: core::time::Duration,
+    ) -> core::pin::Pin<Box<dyn MaybeSendFuture<Output = ()>>> {
+        Box::pin(async move {
+            // Create a JS Promise that resolves after setTimeout, then await it.
+            let ms: i32 = dur.as_millis() as i32;
+            let promise = js_sys::Promise::new(&mut |resolve, _reject| {
+                let window = web_sys::window().expect("window");
+                let cb = Closure::once_into_js(move || {
+                    let _ = resolve.call0(&wasm_bindgen::JsValue::UNDEFINED);
+                });
+                let _ = window.set_timeout_with_callback_and_timeout_and_arguments_0(
+                    cb.as_ref().unchecked_ref(),
+                    ms,
+                );
+            });
+            let _ = wasm_bindgen_futures::JsFuture::from(promise).await;
+        })
+    }
+}

--- a/fusio/src/executor/tokio.rs
+++ b/fusio/src/executor/tokio.rs
@@ -1,0 +1,70 @@
+use std::{error::Error, future::Future};
+
+use fusio_core::{MaybeSend, MaybeSync};
+use tokio::runtime::Handle;
+
+use super::{Executor, JoinHandle, RwLock};
+
+impl<R: MaybeSend> JoinHandle<R> for tokio::task::JoinHandle<R> {
+    async fn join(self) -> Result<R, Box<dyn Error>> {
+        self.await.map_err(|e| Box::new(e) as Box<dyn Error>)
+    }
+}
+
+impl<T: MaybeSend + MaybeSync> RwLock<T> for tokio::sync::RwLock<T> {
+    type ReadGuard<'a>
+        = tokio::sync::RwLockReadGuard<'a, T>
+    where
+        T: 'a;
+    type WriteGuard<'a>
+        = tokio::sync::RwLockWriteGuard<'a, T>
+    where
+        T: 'a;
+
+    async fn read(&self) -> Self::ReadGuard<'_> {
+        ::tokio::sync::RwLock::read(self).await
+    }
+
+    async fn write(&self) -> Self::WriteGuard<'_> {
+        ::tokio::sync::RwLock::write(self).await
+    }
+}
+
+pub struct TokioExecutor {
+    handle: Handle,
+}
+
+impl Default for TokioExecutor {
+    fn default() -> Self {
+        Self {
+            handle: Handle::current(),
+        }
+    }
+}
+
+impl Executor for TokioExecutor {
+    type JoinHandle<R>
+        = tokio::task::JoinHandle<R>
+    where
+        R: MaybeSend;
+
+    type RwLock<T>
+        = tokio::sync::RwLock<T>
+    where
+        T: MaybeSend + MaybeSync;
+
+    fn spawn<F>(&self, future: F) -> Self::JoinHandle<F::Output>
+    where
+        F: Future + MaybeSend + 'static,
+        F::Output: MaybeSend,
+    {
+        self.handle.spawn(future)
+    }
+
+    fn rw_lock<T>(value: T) -> Self::RwLock<T>
+    where
+        T: MaybeSend + MaybeSync,
+    {
+        tokio::sync::RwLock::new(value)
+    }
+}

--- a/fusio/src/lib.rs
+++ b/fusio/src/lib.rs
@@ -51,6 +51,8 @@ pub mod durability;
 #[cfg(feature = "dyn")]
 pub mod dynamic;
 pub mod error;
+#[cfg(feature = "executor")]
+pub mod executor;
 #[cfg(feature = "fs")]
 pub mod fs;
 pub mod impls;


### PR DESCRIPTION
  - Add executor feature to expose lightweight runtime traits:
      - Executor (spawn), JoinHandle (await result), RwLock (async read/write guards).
  - Keeps fusio runtime‑agnostic by default; no new deps unless the feature is enabled.
  - Designed for optional adapters (e.g., Tokio, WASM) without locking libraries into a single runtime.

  Notes

  - No behavior change for existing users unless features = ["executor"] is enabled.
  - Intended to support non-blocking coordination and pluggable runtimes in higher‑level crates.