### PR TITLE
fix(AGENTS.md): do not recommend clippy --all-features and break it down into compatible ones

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,8 +13,23 @@
   - `cargo test -p fusio --features tokio,aws,tokio-http`
   - `cargo test -p fusio-parquet --features tokio`
   - `cargo test -p fusio-log --no-default-features --features aws,bytes,monoio,monoio-http`
-- Lint/format before commits: `cargo +nightly fmt --all`; cargo clippy --workspace --all-features -- -D warnings.
 - Optional WASM checks: `wasm-pack test --chrome --headless fusio[ -parquet ]` with appropriate features.
+
+## Linting & Formatting
+- Format before commits: `cargo +nightly fmt --all`
+- **IMPORTANT:** `--workspace --all-features` does NOT work due to mutually exclusive runtime features (`tokio` vs `monoio`/`tokio-uring`/`opfs` which enable `no-send`).
+- Run clippy per-package with appropriate feature combinations:
+  ```bash
+  cargo clippy -p fusio-core --all-features -- -D warnings
+  cargo clippy -p fusio --features tokio,aws,tokio-http -- -D warnings
+  cargo clippy -p fusio --features monoio,aws,monoio-http -- -D warnings
+  cargo clippy -p fusio-manifest -- -D warnings
+  cargo clippy -p fusio-parquet --features tokio -- -D warnings
+  cargo clippy -p fusio-opendal --all-features -- -D warnings
+  cargo clippy -p fusio-object-store --all-features -- -D warnings
+  cargo clippy -p examples --features tokio -- -D warnings
+  ```
+- For CI or pre-commit, test the runtime you're actively developing against.
 
 ## Style Expectations
 - Rust 2021 with rustfmt (max width 100); grouped imports.


### PR DESCRIPTION
## Summary

Fixed incorrect clippy guidance in AGENTS.md that recommended `cargo clippy --workspace --all-features`, which **cannot compile** due to mutually exclusive runtime features.

## Problem

The previous commit (33af0e7) claimed "All main packages now pass: cargo clippy --all-features -- -D warnings" but this was never actually true for workspace-level checks. Running `cargo clippy --workspace --all-features` produces 52+ compilation errors in `fusio-manifest`.

### Root Cause

Fusio has a fundamental architectural constraint:

- **Multi-threaded runtimes** (`tokio`, `tokio-http`) require `Send + Sync` bounds
- **Single-threaded/completion-based runtimes** (`monoio`, `tokio-uring`, `opfs`) enable the `no-send` feature, which removes `Send + Sync` bounds by making `MaybeSend` and `MaybeSync` apply to all types
- **`fusio-manifest`** hardcodes `tokio-http` in its dependencies and requires `Send + Sync` throughout

When `--all-features` is enabled:
1. Both `tokio` AND `monoio` features are active
2. `monoio` enables `no-send`
3. `DynHttpClient` trait bounds become `MaybeSend + MaybeSync` (no actual bounds)
4. `fusio-manifest` requires `Send + Sync`, which `dyn DynHttpClient` doesn't satisfy
5. Compilation fails with trait bound errors

**These constraints are mutually exclusive by design.**

## Solution

Updated AGENTS.md to:

1. **Document the limitation** with a clear warning explaining why `--workspace --all-features` doesn't work
2. **Provide per-package clippy commands** with valid feature combinations:
   - `fusio-core`, `fusio-opendal`, `fusio-object-store`: Can use `--all-features` (no conflicts)
   - `fusio`: Test separately with `tokio,aws,tokio-http` AND `monoio,aws,monoio-http`
   - `fusio-manifest`: Default features only (tokio-only, no feature flags needed)
   - `fusio-parquet`, `examples`: Use `--features tokio`
3. **Add guidance** for developers to test the runtime they're actively developing against

All 8 documented clippy commands have been verified to pass with `-D warnings`.

## Testing

```bash
# All commands pass cleanly:
cargo clippy -p fusio-core --all-features -- -D warnings
cargo clippy -p fusio --features tokio,aws,tokio-http -- -D warnings
cargo clippy -p fusio --features monoio,aws,monoio-http -- -D warnings
cargo clippy -p fusio-manifest -- -D warnings
cargo clippy -p fusio-parquet --features tokio -- -D warnings
cargo clippy -p fusio-opendal --all-features -- -D warnings
cargo clippy -p fusio-object-store --all-features -- -D warnings
cargo clippy -p examples --features tokio -- -D warnings
```

## Files Changed

- **AGENTS.md**:
  - Removed incorrect `cargo clippy --workspace --all-features` recommendation
  - Added new "Linting & Formatting" section with correct per-package commands
  - Added explanation of the `no-send` feature incompatibility

## Impact

- ✅ Developers will no longer encounter confusing compilation errors
- ✅ Clear guidance on which feature combinations are valid
- ✅ CI/pre-commit workflows can be correctly configured per-runtime
- ✅ Documents the architectural constraint for future contributors

## Notes

This doesn't change any code behavior - it's purely documentation to reflect the actual constraints of the codebase architecture. The multi-runtime design is intentional and working as designed; `--all-features` simply cannot activate all runtimes simultaneously due to their mutually exclusive threading models.