### PR TITLE
enhancement(ci): add pre-commit hook to avoid failed runs in CI

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+cd "${ROOT_DIR}"
+
+if ! command -v cargo >/dev/null 2>&1; then
+  echo "[fusio pre-commit] skipping: cargo not found" >&2
+  exit 0
+fi
+
+run_step() {
+  local cmd="$1"
+  echo "[fusio pre-commit] $cmd"
+  if ! eval "$cmd"; then
+    echo "[fusio pre-commit] command failed: $cmd" >&2
+    exit 1
+  fi
+}
+
+FMT_BIN="cargo +nightly"
+if ! command -v rustup >/dev/null 2>&1; then
+  echo "[fusio pre-commit] rustup not detected; install rustup and the nightly toolchain" >&2
+  exit 1
+fi
+if ! rustup toolchain list | grep -q "nightly"; then
+  echo "[fusio pre-commit] nightly toolchain required (rustup toolchain install nightly)" >&2
+  exit 1
+fi
+FMT_CHECK_CMD="${FMT_BIN} fmt --all -- --check"
+
+run_step "${FMT_CHECK_CMD}"
+run_step "cargo check --workspace --all-targets"
+run_step "cargo clippy -p fusio-core --all-features -- -D warnings"
+run_step "cargo clippy -p fusio --features tokio,aws,tokio-http -- -D warnings"
+run_step "cargo clippy -p fusio --features monoio,aws,monoio-http -- -D warnings"
+run_step "cargo clippy -p fusio-manifest -- -D warnings"
+run_step "cargo clippy -p fusio-parquet --features tokio -- -D warnings"
+run_step "cargo clippy -p fusio-opendal --all-features -- -D warnings"
+run_step "cargo clippy -p fusio-object-store --all-features -- -D warnings"
+run_step "cargo test -p fusio --features tokio,aws,tokio-http"
+run_step "cargo test -p fusio-parquet --features tokio"
+
+exit 0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,11 @@
   ```
 - For CI or pre-commit, test the runtime you're actively developing against.
 
+## Pre-commit Hook
+- Enable tracked hooks once per clone: `git config core.hooksPath .githooks`.
+- Hook runs the full local suite and requires the nightly toolchain (`rustup toolchain install nightly`): `cargo +nightly fmt --all -- --check`, `cargo check --workspace --all-targets`, the clippy matrix (`fusio-core`, `fusio` with tokio + monoio features, `fusio-manifest`, `fusio-parquet`, `fusio-opendal`, `fusio-object-store`), and `cargo test -p fusio --features tokio,aws,tokio-http` plus `cargo test -p fusio-parquet --features tokio`.
+- If rustfmt rewrites files, re-stage and re-commit after running `cargo fmt`; clippy is lint-only.
+
 ## Style Expectations
 - Rust 2021 with rustfmt (max width 100); grouped imports.
 - Idiomatic naming: modules/functions snake_case, types CamelCase, constants SCREAMING_SNAKE_CASE.


### PR DESCRIPTION
Added a tracked pre-commit hook that enforces our full local checklist (nightly rustfmt check, workspace cargo check, full clippy matrix, and the key fusio/fusio-parquet test runs). The hook now requires the nightly toolchain, mirroring CI expectations, and the handbook documents the setup plus nightly prerequisite.
