### PR TITLE
chore(fusio-manifest): add tracing spans for manifest

### DIFF
--- a/fusio-manifest/Cargo.toml
+++ b/fusio-manifest/Cargo.toml
@@ -25,6 +25,7 @@ tokio = { version = "1", features = ["sync"] }
 async-stream = { version = "0.3" }
 backon = "1.4"
 thiserror = "2.0.17"
+tracing = "0.1"
 moka = { version = "0.10", features = ["sync"], optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
## Which issue does this PR close

https://github.com/tonbo-io/fusio/issues/222

## What does this PR do

* Add debug tracing spans to fusio-manifest for better debug-ability 

## What test has this PR have confirmed

`cargo +nightly fmt` `cargo test --lib`